### PR TITLE
✨ install with pip [former]

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,15 @@ type to `pip-compile` to use this plugin for the respective environment.
 
 ### Configuration Options
 
-| name                   | type        | description                                                                                                                           |
-| ---------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| lock-filename          | `str`       | The filename of the ultimate lockfile. `default` env is `requirements.txt`, non-default is `requirements/requirements-{env_name}.txt` |
-| pip-compile-constraint | `str`       | An environment to use as a constraint file, ensuring that all shared dependencies are pinned to the same versions.                    |
-| pip-compile-hashes     | `bool`      | Whether to generate hashes in the lockfile. Defaults to `false`.                                                                      |
-| pip-compile-verbose    | `bool`      | Set to `true` to run `pip-compile` in verbose mode instead of quiet mode, set to `false` to silence warnings                          |
-| pip-compile-installer  | `str`       | Whether to use `pip` or `pip-sync` to install dependencies into the project. Defaults to `pip`                                        |
-| pip-compile-args       | `list[str]` | Additional command-line arguments to pass to `pip-compile`                                                                            |
+| name                     | type        | description                                                                                                                           |
+| ------------------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| lock-filename            | `str`       | The filename of the ultimate lockfile. `default` env is `requirements.txt`, non-default is `requirements/requirements-{env_name}.txt` |
+| pip-compile-constraint   | `str`       | An environment to use as a constraint file, ensuring that all shared dependencies are pinned to the same versions.                    |
+| pip-compile-hashes       | `bool`      | Whether to generate hashes in the lockfile. Defaults to `false`.                                                                      |
+| pip-compile-verbose      | `bool`      | Set to `true` to run `pip-compile` in verbose mode instead of quiet mode, set to `false` to silence warnings                          |
+| pip-compile-installer    | `str`       | Whether to use `pip` or `pip-sync` to install dependencies into the project. Defaults to `pip`                                        |
+| pip-compile-args         | `list[str]` | Additional command-line arguments to pass to `pip-compile`                                                                            |
+| pip-compile-install-args | `list[str]` | Additional command-line arguments to pass to `pip-compile-installer`                                                                  |
 
 #### Examples
 
@@ -298,6 +299,33 @@ across different Python versions and platforms `pip` is the safer option to use.
     [envs.<envName>]
     type = "pip-compile"
     pip-compile-installer = "pip-sync"
+    ```
+
+##### pip-compile-install-args
+
+Extra arguments to pass to `pip-compile-installer`. For example, if you'd like to use `pip` as the
+installer but want to pass the `--no-deps` flag to `pip install` you can do so with this option:
+
+-   **_pyproject.toml_**
+
+    ```toml
+    [tool.hatch.envs.<envName>]
+    type = "pip-compile"
+    pip-compile-installer = "pip"
+    pip-compile-install-args = [
+        "--no-deps"
+    ]
+    ```
+
+-   **_hatch.toml_**
+
+    ```toml
+    [envs.<envName>]
+    type = "pip-compile"
+    pip-compile-installer = "pip"
+    pip-compile-install-args = [
+        "--no-deps"
+    ]
     ```
 
 ## Upgrading Dependencies

--- a/README.md
+++ b/README.md
@@ -84,15 +84,25 @@ type to `pip-compile` to use this plugin for the respective environment.
 
 ### Configuration Options
 
-| name                     | type        | description                                                                                                                           |
-| ------------------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| lock-filename            | `str`       | The filename of the ultimate lockfile. `default` env is `requirements.txt`, non-default is `requirements/requirements-{env_name}.txt` |
-| pip-compile-constraint   | `str`       | An environment to use as a constraint file, ensuring that all shared dependencies are pinned to the same versions.                    |
-| pip-compile-hashes       | `bool`      | Whether to generate hashes in the lockfile. Defaults to `false`.                                                                      |
-| pip-compile-verbose      | `bool`      | Set to `true` to run `pip-compile` in verbose mode instead of quiet mode, set to `false` to silence warnings                          |
-| pip-compile-installer    | `str`       | Whether to use `pip` or `pip-sync` to install dependencies into the project. Defaults to `pip`                                        |
-| pip-compile-args         | `list[str]` | Additional command-line arguments to pass to `pip-compile`                                                                            |
-| pip-compile-install-args | `list[str]` | Additional command-line arguments to pass to `pip-compile-installer`                                                                  |
+The plugin gives you options to configure how lockfiles are generated and how they are installed
+into your environment.
+
+#### Generating Lockfiles
+
+| name                   | type        | description                                                                                                                           |
+| ---------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| lock-filename          | `str`       | The filename of the ultimate lockfile. `default` env is `requirements.txt`, non-default is `requirements/requirements-{env_name}.txt` |
+| pip-compile-constraint | `str`       | An environment to use as a constraint file, ensuring that all shared dependencies are pinned to the same versions.                    |
+| pip-compile-hashes     | `bool`      | Whether to generate hashes in the lockfile. Defaults to `false`.                                                                      |
+| pip-compile-verbose    | `bool`      | Set to `true` to run `pip-compile` in verbose mode instead of quiet mode, set to `false` to silence warnings                          |
+| pip-compile-args       | `list[str]` | Additional command-line arguments to pass to `pip-compile`                                                                            |
+
+#### Installing Lockfiles
+
+| name                     | type        | description                                                                                    |
+| ------------------------ | ----------- | ---------------------------------------------------------------------------------------------- |
+| pip-compile-installer    | `str`       | Whether to use `pip` or `pip-sync` to install dependencies into the project. Defaults to `pip` |
+| pip-compile-install-args | `list[str]` | Additional command-line arguments to pass to `pip-compile-installer`                           |
 
 #### Examples
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@ your environment type set to `pip-compile` (see [Configuration](#configuration))
 The `hatch-pip-compile` plugin will automatically run `pip-compile` whenever your
 environment needs to be updated. Behind the scenes, this plugin creates a lockfile
 at `requirements.txt` (non-default lockfiles are located at
-`requirements/requirements-{env_name}.txt`). Alongside `pip-compile`, this plugin also
-uses [pip-sync] to install the dependencies from the lockfile into your environment.
+`requirements/requirements-{env_name}.txt`).
 
 -   [lock-filename](#lock-filename) - changing the default lockfile path
 -   [pip-compile-constraint](#pip-compile-constraint) - syncing dependency versions across environments
@@ -90,6 +89,7 @@ type to `pip-compile` to use this plugin for the respective environment.
 | pip-compile-constraint | `str`       | An environment to use as a constraint file, ensuring that all shared dependencies are pinned to the same versions.                    |
 | pip-compile-hashes     | `bool`      | Whether to generate hashes in the lockfile. Defaults to `false`.                                                                      |
 | pip-compile-verbose    | `bool`      | Set to `true` to run `pip-compile` in verbose mode instead of quiet mode, set to `false` to silence warnings                          |
+| pip-compile-installer  | `str`       | Whether to use `pip` or `pip-sync` to install dependencies into the project. Defaults to `pip`                                        |
 | pip-compile-args       | `list[str]` | Additional command-line arguments to pass to `pip-compile`                                                                            |
 
 #### Examples
@@ -270,6 +270,34 @@ Optionally, if you would like to silence any warnings set the `pip-compile-verbo
     [envs.<envName>]
     type = "pip-compile"
     pip-compile-verbose = true
+    ```
+
+##### pip-compile-installer
+
+Whether to use [pip] or [pip-sync] to install dependencies into the project. Defaults to `pip`.
+When you choose the `pip` option the plugin will run `pip install -r {lockfile}` under the hood
+to install the dependencies. When you choose the `pip-sync` option `pip-sync {lockfile}` is invoked
+by the plugin.
+
+The key difference between these options is that `pip-sync` will uninstall any packages that are
+not in the lockfile and remove them from your environment. `pip-sync` is useful if you want to ensure
+that your environment is exactly the same as the lockfile. If the environment should be used
+across different Python versions and platforms `pip` is the safer option to use.
+
+-   **_pyproject.toml_**
+
+    ```toml
+    [tool.hatch.envs.<envName>]
+    type = "pip-compile"
+    pip-compile-installer = "pip-sync"
+    ```
+
+-   **_hatch.toml_**
+
+    ```toml
+    [envs.<envName>]
+    type = "pip-compile"
+    pip-compile-installer = "pip-sync"
     ```
 
 ## Upgrading Dependencies

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ your environment type set to `pip-compile` (see [Configuration](#configuration))
 The `hatch-pip-compile` plugin will automatically run `pip-compile` whenever your
 environment needs to be updated. Behind the scenes, this plugin creates a lockfile
 at `requirements.txt` (non-default lockfiles are located at
-`requirements/requirements-{env_name}.txt`).
+`requirements/requirements-{env_name}.txt`). Once the dependencies are resolved
+the plugin will install the lockfile into your virtual environment.
 
 -   [lock-filename](#lock-filename) - changing the default lockfile path
 -   [pip-compile-constraint](#pip-compile-constraint) - syncing dependency versions across environments

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,14 +81,15 @@ type to `pip-compile` to use this plugin for the respective environment.
 
 ### Configuration Options
 
-| name                   | type        | description                                                                                                                           |
-| ---------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| lock-filename          | `str`       | The filename of the ultimate lockfile. `default` env is `requirements.txt`, non-default is `requirements/requirements-{env_name}.txt` |
-| pip-compile-constraint | `str`       | An environment to use as a constraint file, ensuring that all shared dependencies are pinned to the same versions.                    |
-| pip-compile-hashes     | `bool`      | Whether to generate hashes in the lockfile. Defaults to `false`.                                                                      |
-| pip-compile-verbose    | `bool`      | Set to `true` to run `pip-compile` in verbose mode instead of quiet mode, set to `false` to silence warnings                          |
-| pip-compile-installer  | `str`       | Whether to use `pip` or `pip-sync` to install dependencies into the project. Defaults to `pip`                                        |
-| pip-compile-args       | `list[str]` | Additional command-line arguments to pass to `pip-compile`                                                                            |
+| name                     | type        | description                                                                                                                           |
+| ------------------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| lock-filename            | `str`       | The filename of the ultimate lockfile. `default` env is `requirements.txt`, non-default is `requirements/requirements-{env_name}.txt` |
+| pip-compile-constraint   | `str`       | An environment to use as a constraint file, ensuring that all shared dependencies are pinned to the same versions.                    |
+| pip-compile-hashes       | `bool`      | Whether to generate hashes in the lockfile. Defaults to `false`.                                                                      |
+| pip-compile-verbose      | `bool`      | Set to `true` to run `pip-compile` in verbose mode instead of quiet mode, set to `false` to silence warnings                          |
+| pip-compile-installer    | `str`       | Whether to use `pip` or `pip-sync` to install dependencies into the project. Defaults to `pip`                                        |
+| pip-compile-args         | `list[str]` | Additional command-line arguments to pass to `pip-compile`                                                                            |
+| pip-compile-install-args | `list[str]` | Additional command-line arguments to pass to `pip-compile-installer`                                                                  |
 
 #### Examples
 
@@ -296,6 +297,33 @@ across different Python versions and platforms `pip` is the safer option to use.
     [envs.<envName>]
     type = "pip-compile"
     pip-compile-installer = "pip-sync"
+    ```
+
+##### pip-compile-install-args
+
+Extra arguments to pass to `pip-compile-installer`. For example, if you'd like to use `pip` as the
+installer but want to pass the `--no-deps` flag to `pip install` you can do so with this option:
+
+-   **_pyproject.toml_**
+
+    ```toml
+    [tool.hatch.envs.<envName>]
+    type = "pip-compile"
+    pip-compile-installer = "pip"
+    pip-compile-install-args = [
+        "--no-deps"
+    ]
+    ```
+
+-   **_hatch.toml_**
+
+    ```toml
+    [envs.<envName>]
+    type = "pip-compile"
+    pip-compile-installer = "pip"
+    pip-compile-install-args = [
+        "--no-deps"
+    ]
     ```
 
 ## Upgrading Dependencies

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,15 +82,25 @@ type to `pip-compile` to use this plugin for the respective environment.
 
 ### Configuration Options
 
-| name                     | type        | description                                                                                                                           |
-| ------------------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| lock-filename            | `str`       | The filename of the ultimate lockfile. `default` env is `requirements.txt`, non-default is `requirements/requirements-{env_name}.txt` |
-| pip-compile-constraint   | `str`       | An environment to use as a constraint file, ensuring that all shared dependencies are pinned to the same versions.                    |
-| pip-compile-hashes       | `bool`      | Whether to generate hashes in the lockfile. Defaults to `false`.                                                                      |
-| pip-compile-verbose      | `bool`      | Set to `true` to run `pip-compile` in verbose mode instead of quiet mode, set to `false` to silence warnings                          |
-| pip-compile-installer    | `str`       | Whether to use `pip` or `pip-sync` to install dependencies into the project. Defaults to `pip`                                        |
-| pip-compile-args         | `list[str]` | Additional command-line arguments to pass to `pip-compile`                                                                            |
-| pip-compile-install-args | `list[str]` | Additional command-line arguments to pass to `pip-compile-installer`                                                                  |
+The plugin gives you options to configure how lockfiles are generated and how they are installed
+into your environment.
+
+#### Generating Lockfiles
+
+| name                   | type        | description                                                                                                                           |
+| ---------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| lock-filename          | `str`       | The filename of the ultimate lockfile. `default` env is `requirements.txt`, non-default is `requirements/requirements-{env_name}.txt` |
+| pip-compile-constraint | `str`       | An environment to use as a constraint file, ensuring that all shared dependencies are pinned to the same versions.                    |
+| pip-compile-hashes     | `bool`      | Whether to generate hashes in the lockfile. Defaults to `false`.                                                                      |
+| pip-compile-verbose    | `bool`      | Set to `true` to run `pip-compile` in verbose mode instead of quiet mode, set to `false` to silence warnings                          |
+| pip-compile-args       | `list[str]` | Additional command-line arguments to pass to `pip-compile`                                                                            |
+
+#### Installing Lockfiles
+
+| name                     | type        | description                                                                                    |
+| ------------------------ | ----------- | ---------------------------------------------------------------------------------------------- |
+| pip-compile-installer    | `str`       | Whether to use `pip` or `pip-sync` to install dependencies into the project. Defaults to `pip` |
+| pip-compile-install-args | `list[str]` | Additional command-line arguments to pass to `pip-compile-installer`                           |
 
 #### Examples
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,8 @@ your environment type set to `pip-compile` (see [Configuration](#configuration))
 The `hatch-pip-compile` plugin will automatically run `pip-compile` whenever your
 environment needs to be updated. Behind the scenes, this plugin creates a lockfile
 at `requirements.txt` (non-default lockfiles are located at
-`requirements/requirements-{env_name}.txt`).
+`requirements/requirements-{env_name}.txt`). Once the dependencies are resolved
+the plugin will install the lockfile into your virtual environment.
 
 -   [lock-filename](#lock-filename) - changing the default lockfile path
 -   [pip-compile-constraint](#pip-compile-constraint) - syncing dependency versions across environments

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,8 +54,7 @@ your environment type set to `pip-compile` (see [Configuration](#configuration))
 The `hatch-pip-compile` plugin will automatically run `pip-compile` whenever your
 environment needs to be updated. Behind the scenes, this plugin creates a lockfile
 at `requirements.txt` (non-default lockfiles are located at
-`requirements/requirements-{env_name}.txt`). Alongside `pip-compile`, this plugin also
-uses [pip-sync] to install the dependencies from the lockfile into your environment.
+`requirements/requirements-{env_name}.txt`).
 
 -   [lock-filename](#lock-filename) - changing the default lockfile path
 -   [pip-compile-constraint](#pip-compile-constraint) - syncing dependency versions across environments
@@ -88,6 +87,7 @@ type to `pip-compile` to use this plugin for the respective environment.
 | pip-compile-constraint | `str`       | An environment to use as a constraint file, ensuring that all shared dependencies are pinned to the same versions.                    |
 | pip-compile-hashes     | `bool`      | Whether to generate hashes in the lockfile. Defaults to `false`.                                                                      |
 | pip-compile-verbose    | `bool`      | Set to `true` to run `pip-compile` in verbose mode instead of quiet mode, set to `false` to silence warnings                          |
+| pip-compile-installer  | `str`       | Whether to use `pip` or `pip-sync` to install dependencies into the project. Defaults to `pip`                                        |
 | pip-compile-args       | `list[str]` | Additional command-line arguments to pass to `pip-compile`                                                                            |
 
 #### Examples
@@ -268,6 +268,34 @@ Optionally, if you would like to silence any warnings set the `pip-compile-verbo
     [envs.<envName>]
     type = "pip-compile"
     pip-compile-verbose = true
+    ```
+
+##### pip-compile-installer
+
+Whether to use [pip] or [pip-sync] to install dependencies into the project. Defaults to `pip`.
+When you choose the `pip` option the plugin will run `pip install -r {lockfile}` under the hood
+to install the dependencies. When you choose the `pip-sync` option `pip-sync {lockfile}` is invoked
+by the plugin.
+
+The key difference between these options is that `pip-sync` will uninstall any packages that are
+not in the lockfile and remove them from your environment. `pip-sync` is useful if you want to ensure
+that your environment is exactly the same as the lockfile. If the environment should be used
+across different Python versions and platforms `pip` is the safer option to use.
+
+-   **_pyproject.toml_**
+
+    ```toml
+    [tool.hatch.envs.<envName>]
+    type = "pip-compile"
+    pip-compile-installer = "pip-sync"
+    ```
+
+-   **_hatch.toml_**
+
+    ```toml
+    [envs.<envName>]
+    type = "pip-compile"
+    pip-compile-installer = "pip-sync"
     ```
 
 ## Upgrading Dependencies

--- a/hatch_pip_compile/plugin.py
+++ b/hatch_pip_compile/plugin.py
@@ -389,9 +389,8 @@ class PipCompileEnvironment(VirtualEnvironment):
         Install the project (`--no-deps`)
         """
         with self.safe_activation():
-            proj_with_feats = self.apply_features(str(self.root))
             self.platform.check_command(
-                self.construct_pip_install_command(args=["--no-deps", proj_with_feats])
+                self.construct_pip_install_command(args=["--no-deps", str(self.root)])
             )
 
     def install_project_no_deps_dev(self) -> None:
@@ -399,9 +398,6 @@ class PipCompileEnvironment(VirtualEnvironment):
         Install the project in editable mode (`--no-deps`)
         """
         with self.safe_activation():
-            proj_with_feats = self.apply_features(str(self.root))
             self.platform.check_command(
-                self.construct_pip_install_command(
-                    args=["--no-deps", "--editable", proj_with_feats]
-                )
+                self.construct_pip_install_command(args=["--no-deps", "--editable", str(self.root)])
             )

--- a/hatch_pip_compile/plugin.py
+++ b/hatch_pip_compile/plugin.py
@@ -189,11 +189,6 @@ class PipCompileEnvironment(VirtualEnvironment):
         self.virtual_env.platform.check_command(cmd)
         if not self.dependencies:
             self._piptools_lock_file.unlink()
-        if not self.skip_install:
-            if self.dev_mode:
-                self.install_project_no_deps_dev()
-            else:
-                self.install_project_no_deps()
 
     def install_project(self):
         """

--- a/hatch_pip_compile/plugin.py
+++ b/hatch_pip_compile/plugin.py
@@ -104,9 +104,9 @@ class PipCompileEnvironment(VirtualEnvironment):
             self._piptools_install_dependencies()
             if not self.skip_install:
                 if self.dev_mode:
-                    self._install_project_dev_mode()
+                    self.install_project_no_deps_dev()
                 else:
-                    self._install_project()
+                    self.install_project_no_deps()
 
     def _pip_compile_cli(self) -> None:
         """
@@ -191,9 +191,9 @@ class PipCompileEnvironment(VirtualEnvironment):
             self._piptools_lock_file.unlink()
         if not self.skip_install:
             if self.dev_mode:
-                self._install_project_dev_mode()
+                self.install_project_no_deps_dev()
             else:
-                self._install_project()
+                self.install_project_no_deps()
 
     def install_project(self):
         """
@@ -384,7 +384,7 @@ class PipCompileEnvironment(VirtualEnvironment):
             msg = f"Invalid pip-tools install method: {self.install_method}"
             raise NotImplementedError(msg)
 
-    def _install_project(self) -> None:
+    def install_project_no_deps(self) -> None:
         """
         Install the project (`--no-deps`)
         """
@@ -394,7 +394,7 @@ class PipCompileEnvironment(VirtualEnvironment):
                 self.construct_pip_install_command(args=["--no-deps", proj_with_feats])
             )
 
-    def _install_project_dev_mode(self) -> None:
+    def install_project_no_deps_dev(self) -> None:
         """
         Install the project in editable mode (`--no-deps`)
         """


### PR DESCRIPTION
closes #29 

## Changes

- Changes default behavior to run `pip install -r lockfile.txt` instead of `pip-sync lockfile.txt`
    - Makes this a configurable option, `pip-compile-installer`
- Only forces project reinstall when using `pip-sync` option
- Deletes lockfile if no dependencies with both `pip` and `pip-sync` options