### PR TITLE
✨ install with pip - alternate proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ your environment type set to `pip-compile` (see [Configuration](#configuration))
 The `hatch-pip-compile` plugin will automatically run `pip-compile` whenever your
 environment needs to be updated. Behind the scenes, this plugin creates a lockfile
 at `requirements.txt` (non-default lockfiles are located at
-`requirements/requirements-{env_name}.txt`). Alongside `pip-compile`, this plugin also
-uses [pip-sync] to install the dependencies from the lockfile into your environment.
+`requirements/requirements-{env_name}.txt`). Once the dependencies are resolved
+the plugin will install the lockfile into your virtual environment.
 
 -   [lock-filename](#lock-filename) - changing the default lockfile path
 -   [pip-compile-constraint](#pip-compile-constraint) - syncing dependency versions across environments
@@ -84,6 +84,11 @@ type to `pip-compile` to use this plugin for the respective environment.
 
 ### Configuration Options
 
+The plugin gives you options to configure how lockfiles are generated and how they are installed
+into your environment.
+
+#### Generating Lockfiles
+
 | name                   | type        | description                                                                                                                           |
 | ---------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | lock-filename          | `str`       | The filename of the ultimate lockfile. `default` env is `requirements.txt`, non-default is `requirements/requirements-{env_name}.txt` |
@@ -91,6 +96,13 @@ type to `pip-compile` to use this plugin for the respective environment.
 | pip-compile-hashes     | `bool`      | Whether to generate hashes in the lockfile. Defaults to `false`.                                                                      |
 | pip-compile-verbose    | `bool`      | Set to `true` to run `pip-compile` in verbose mode instead of quiet mode, set to `false` to silence warnings                          |
 | pip-compile-args       | `list[str]` | Additional command-line arguments to pass to `pip-compile`                                                                            |
+
+#### Installing Lockfiles
+
+| name                     | type        | description                                                                                    |
+| ------------------------ | ----------- | ---------------------------------------------------------------------------------------------- |
+| pip-compile-installer    | `str`       | Whether to use `pip` or `pip-sync` to install dependencies into the project. Defaults to `pip` |
+| pip-compile-install-args | `list[str]` | Additional command-line arguments to pass to `pip-compile-installer`                           |
 
 #### Examples
 
@@ -270,6 +282,61 @@ Optionally, if you would like to silence any warnings set the `pip-compile-verbo
     [envs.<envName>]
     type = "pip-compile"
     pip-compile-verbose = true
+    ```
+
+##### pip-compile-installer
+
+Whether to use [pip] or [pip-sync] to install dependencies into the project. Defaults to `pip`.
+When you choose the `pip` option the plugin will run `pip install -r {lockfile}` under the hood
+to install the dependencies. When you choose the `pip-sync` option `pip-sync {lockfile}` is invoked
+by the plugin.
+
+The key difference between these options is that `pip-sync` will uninstall any packages that are
+not in the lockfile and remove them from your environment. `pip-sync` is useful if you want to ensure
+that your environment is exactly the same as the lockfile. If the environment should be used
+across different Python versions and platforms `pip` is the safer option to use.
+
+-   **_pyproject.toml_**
+
+    ```toml
+    [tool.hatch.envs.<envName>]
+    type = "pip-compile"
+    pip-compile-installer = "pip-sync"
+    ```
+
+-   **_hatch.toml_**
+
+    ```toml
+    [envs.<envName>]
+    type = "pip-compile"
+    pip-compile-installer = "pip-sync"
+    ```
+
+##### pip-compile-install-args
+
+Extra arguments to pass to `pip-compile-installer`. For example, if you'd like to use `pip` as the
+installer but want to pass the `--no-deps` flag to `pip install` you can do so with this option:
+
+-   **_pyproject.toml_**
+
+    ```toml
+    [tool.hatch.envs.<envName>]
+    type = "pip-compile"
+    pip-compile-installer = "pip"
+    pip-compile-install-args = [
+        "--no-deps"
+    ]
+    ```
+
+-   **_hatch.toml_**
+
+    ```toml
+    [envs.<envName>]
+    type = "pip-compile"
+    pip-compile-installer = "pip"
+    pip-compile-install-args = [
+        "--no-deps"
+    ]
     ```
 
 ## Upgrading Dependencies

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,8 +54,8 @@ your environment type set to `pip-compile` (see [Configuration](#configuration))
 The `hatch-pip-compile` plugin will automatically run `pip-compile` whenever your
 environment needs to be updated. Behind the scenes, this plugin creates a lockfile
 at `requirements.txt` (non-default lockfiles are located at
-`requirements/requirements-{env_name}.txt`). Alongside `pip-compile`, this plugin also
-uses [pip-sync] to install the dependencies from the lockfile into your environment.
+`requirements/requirements-{env_name}.txt`). Once the dependencies are resolved
+the plugin will install the lockfile into your virtual environment.
 
 -   [lock-filename](#lock-filename) - changing the default lockfile path
 -   [pip-compile-constraint](#pip-compile-constraint) - syncing dependency versions across environments
@@ -82,6 +82,11 @@ type to `pip-compile` to use this plugin for the respective environment.
 
 ### Configuration Options
 
+The plugin gives you options to configure how lockfiles are generated and how they are installed
+into your environment.
+
+#### Generating Lockfiles
+
 | name                   | type        | description                                                                                                                           |
 | ---------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | lock-filename          | `str`       | The filename of the ultimate lockfile. `default` env is `requirements.txt`, non-default is `requirements/requirements-{env_name}.txt` |
@@ -89,6 +94,13 @@ type to `pip-compile` to use this plugin for the respective environment.
 | pip-compile-hashes     | `bool`      | Whether to generate hashes in the lockfile. Defaults to `false`.                                                                      |
 | pip-compile-verbose    | `bool`      | Set to `true` to run `pip-compile` in verbose mode instead of quiet mode, set to `false` to silence warnings                          |
 | pip-compile-args       | `list[str]` | Additional command-line arguments to pass to `pip-compile`                                                                            |
+
+#### Installing Lockfiles
+
+| name                     | type        | description                                                                                    |
+| ------------------------ | ----------- | ---------------------------------------------------------------------------------------------- |
+| pip-compile-installer    | `str`       | Whether to use `pip` or `pip-sync` to install dependencies into the project. Defaults to `pip` |
+| pip-compile-install-args | `list[str]` | Additional command-line arguments to pass to `pip-compile-installer`                           |
 
 #### Examples
 
@@ -268,6 +280,61 @@ Optionally, if you would like to silence any warnings set the `pip-compile-verbo
     [envs.<envName>]
     type = "pip-compile"
     pip-compile-verbose = true
+    ```
+
+##### pip-compile-installer
+
+Whether to use [pip] or [pip-sync] to install dependencies into the project. Defaults to `pip`.
+When you choose the `pip` option the plugin will run `pip install -r {lockfile}` under the hood
+to install the dependencies. When you choose the `pip-sync` option `pip-sync {lockfile}` is invoked
+by the plugin.
+
+The key difference between these options is that `pip-sync` will uninstall any packages that are
+not in the lockfile and remove them from your environment. `pip-sync` is useful if you want to ensure
+that your environment is exactly the same as the lockfile. If the environment should be used
+across different Python versions and platforms `pip` is the safer option to use.
+
+-   **_pyproject.toml_**
+
+    ```toml
+    [tool.hatch.envs.<envName>]
+    type = "pip-compile"
+    pip-compile-installer = "pip-sync"
+    ```
+
+-   **_hatch.toml_**
+
+    ```toml
+    [envs.<envName>]
+    type = "pip-compile"
+    pip-compile-installer = "pip-sync"
+    ```
+
+##### pip-compile-install-args
+
+Extra arguments to pass to `pip-compile-installer`. For example, if you'd like to use `pip` as the
+installer but want to pass the `--no-deps` flag to `pip install` you can do so with this option:
+
+-   **_pyproject.toml_**
+
+    ```toml
+    [tool.hatch.envs.<envName>]
+    type = "pip-compile"
+    pip-compile-installer = "pip"
+    pip-compile-install-args = [
+        "--no-deps"
+    ]
+    ```
+
+-   **_hatch.toml_**
+
+    ```toml
+    [envs.<envName>]
+    type = "pip-compile"
+    pip-compile-installer = "pip"
+    pip-compile-install-args = [
+        "--no-deps"
+    ]
     ```
 
 ## Upgrading Dependencies

--- a/hatch_pip_compile/plugin.py
+++ b/hatch_pip_compile/plugin.py
@@ -89,6 +89,9 @@ class PipCompileEnvironment(VirtualEnvironment):
         """
         Run pip-compile
         """
+        if not self.dependencies:
+            self._piptools_lock_file.unlink(missing_ok=True)
+            return
         no_compile = bool(os.getenv("PIP_COMPILE_DISABLE"))
         if no_compile:
             msg = "hatch-pip-compile is disabled but attempted to run a lockfile update."
@@ -313,6 +316,8 @@ class PipCompileEnvironmentWithPipInstall(PipCompileEnvironment):
                     self.construct_pip_install_command(["pip-tools"])
                 )
                 self._pip_compile_cli()
+            if not self._piptools_lock_file.exists():
+                return
             extra_args = self.config.get("pip-compile-install-args", [])
             args = [*extra_args, "--requirement", str(self._piptools_lock_file)]
             install_command = self.construct_pip_install_command(args=args)

--- a/hatch_pip_compile/plugin.py
+++ b/hatch_pip_compile/plugin.py
@@ -82,6 +82,7 @@ class PipCompileEnvironment(VirtualEnvironment):
             "pip-compile-args": List[str],
             "pip-compile-constraint": str,
             "pip-compile-installer": str,
+            "pip-compile-install-args": List[str],
         }
 
     def _pip_compile_cli(self) -> None:
@@ -365,10 +366,12 @@ class PipCompileEnvironmentWithPipSync(PipCompileEnvironment):
             "--verbose" if self.config.get("pip-compile-verbose", None) is True else "--quiet",
             "--python-executable",
             str(self.virtual_env.python_info.executable),
-            str(self._piptools_lock_file),
         ]
         if not self.dependencies:
             self._piptools_lock_file.write_text("")
+        extra_args = self.config.get("pip-compile-install-args", [])
+        cmd.extend(extra_args)
+        cmd.append(str(self._piptools_lock_file))
         self.virtual_env.platform.check_command(cmd)
         if not self.dependencies:
             self._piptools_lock_file.unlink()

--- a/hatch_pip_compile/plugin.py
+++ b/hatch_pip_compile/plugin.py
@@ -282,6 +282,24 @@ class PipCompileEnvironment(VirtualEnvironment):
         """
         return self.metadata.hatch.config.get("envs", {})
 
+    def install_project(self) -> None:
+        """
+        Install the project (`--no-deps`)
+        """
+        with self.safe_activation():
+            self.platform.check_command(
+                self.construct_pip_install_command(args=["--no-deps", str(self.root)])
+            )
+
+    def install_project_dev_mode(self) -> None:
+        """
+        Install the project in editable mode (`--no-deps`)
+        """
+        with self.safe_activation():
+            self.platform.check_command(
+                self.construct_pip_install_command(args=["--no-deps", "--editable", str(self.root)])
+            )
+
 
 class PipCompileEnvironmentWithPipInstall(PipCompileEnvironment):
     def sync_dependencies(self) -> None:


### PR DESCRIPTION
Alternative to #30 - mostly untested for now, early code.

Please look at it commit by commit.
In particular this commit shows **the very core of the idea**:
https://github.com/oprypin/hatch-pip-compile/commit/1d5f100de5d6f57338d9a1dcf11f00484d501153

why don't we leave the complexity of 'pip-sync' behind and make a fresh subclass that knows nothing about pip-sync and doesn't need to replace many methods in a complicated way

I'm honestly so proud of this approach, the only horrible thing is that the object replaces its own `__class__` on the fly. But I'm pretty sure this will just work with no problems.