### PR TITLE
✨ install with pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ your environment type set to `pip-compile` (see [Configuration](#configuration))
 The `hatch-pip-compile` plugin will automatically run `pip-compile` whenever your
 environment needs to be updated. Behind the scenes, this plugin creates a lockfile
 at `requirements.txt` (non-default lockfiles are located at
-`requirements/requirements-{env_name}.txt`). Alongside `pip-compile`, this plugin also
-uses [pip-sync] to install the dependencies from the lockfile into your environment.
+`requirements/requirements-{env_name}.txt`). Once the dependencies are resolved
+the plugin will install the lockfile into your virtual environment.
 
 -   [lock-filename](#lock-filename) - changing the default lockfile path
 -   [pip-compile-constraint](#pip-compile-constraint) - syncing dependency versions across environments
@@ -84,6 +84,11 @@ type to `pip-compile` to use this plugin for the respective environment.
 
 ### Configuration Options
 
+The plugin gives you options to configure how lockfiles are generated and how they are installed
+into your environment.
+
+#### Generating Lockfiles
+
 | name                   | type        | description                                                                                                                           |
 | ---------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | lock-filename          | `str`       | The filename of the ultimate lockfile. `default` env is `requirements.txt`, non-default is `requirements/requirements-{env_name}.txt` |
@@ -91,6 +96,13 @@ type to `pip-compile` to use this plugin for the respective environment.
 | pip-compile-hashes     | `bool`      | Whether to generate hashes in the lockfile. Defaults to `false`.                                                                      |
 | pip-compile-verbose    | `bool`      | Set to `true` to run `pip-compile` in verbose mode instead of quiet mode, set to `false` to silence warnings                          |
 | pip-compile-args       | `list[str]` | Additional command-line arguments to pass to `pip-compile`                                                                            |
+
+#### Installing Lockfiles
+
+| name                     | type        | description                                                                                    |
+| ------------------------ | ----------- | ---------------------------------------------------------------------------------------------- |
+| pip-compile-installer    | `str`       | Whether to use `pip` or `pip-sync` to install dependencies into the project. Defaults to `pip` |
+| pip-compile-install-args | `list[str]` | Additional command-line arguments to pass to `pip-compile-installer`                           |
 
 #### Examples
 
@@ -270,6 +282,61 @@ Optionally, if you would like to silence any warnings set the `pip-compile-verbo
     [envs.<envName>]
     type = "pip-compile"
     pip-compile-verbose = true
+    ```
+
+##### pip-compile-installer
+
+Whether to use [pip] or [pip-sync] to install dependencies into the project. Defaults to `pip`.
+When you choose the `pip` option the plugin will run `pip install -r {lockfile}` under the hood
+to install the dependencies. When you choose the `pip-sync` option `pip-sync {lockfile}` is invoked
+by the plugin.
+
+The key difference between these options is that `pip-sync` will uninstall any packages that are
+not in the lockfile and remove them from your environment. `pip-sync` is useful if you want to ensure
+that your environment is exactly the same as the lockfile. If the environment should be used
+across different Python versions and platforms `pip` is the safer option to use.
+
+-   **_pyproject.toml_**
+
+    ```toml
+    [tool.hatch.envs.<envName>]
+    type = "pip-compile"
+    pip-compile-installer = "pip-sync"
+    ```
+
+-   **_hatch.toml_**
+
+    ```toml
+    [envs.<envName>]
+    type = "pip-compile"
+    pip-compile-installer = "pip-sync"
+    ```
+
+##### pip-compile-install-args
+
+Extra arguments to pass to `pip-compile-installer`. For example, if you'd like to use `pip` as the
+installer but want to pass the `--no-deps` flag to `pip install` you can do so with this option:
+
+-   **_pyproject.toml_**
+
+    ```toml
+    [tool.hatch.envs.<envName>]
+    type = "pip-compile"
+    pip-compile-installer = "pip"
+    pip-compile-install-args = [
+        "--no-deps"
+    ]
+    ```
+
+-   **_hatch.toml_**
+
+    ```toml
+    [envs.<envName>]
+    type = "pip-compile"
+    pip-compile-installer = "pip"
+    pip-compile-install-args = [
+        "--no-deps"
+    ]
     ```
 
 ## Upgrading Dependencies

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,8 +54,8 @@ your environment type set to `pip-compile` (see [Configuration](#configuration))
 The `hatch-pip-compile` plugin will automatically run `pip-compile` whenever your
 environment needs to be updated. Behind the scenes, this plugin creates a lockfile
 at `requirements.txt` (non-default lockfiles are located at
-`requirements/requirements-{env_name}.txt`). Alongside `pip-compile`, this plugin also
-uses [pip-sync] to install the dependencies from the lockfile into your environment.
+`requirements/requirements-{env_name}.txt`). Once the dependencies are resolved
+the plugin will install the lockfile into your virtual environment.
 
 -   [lock-filename](#lock-filename) - changing the default lockfile path
 -   [pip-compile-constraint](#pip-compile-constraint) - syncing dependency versions across environments
@@ -82,6 +82,11 @@ type to `pip-compile` to use this plugin for the respective environment.
 
 ### Configuration Options
 
+The plugin gives you options to configure how lockfiles are generated and how they are installed
+into your environment.
+
+#### Generating Lockfiles
+
 | name                   | type        | description                                                                                                                           |
 | ---------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | lock-filename          | `str`       | The filename of the ultimate lockfile. `default` env is `requirements.txt`, non-default is `requirements/requirements-{env_name}.txt` |
@@ -89,6 +94,13 @@ type to `pip-compile` to use this plugin for the respective environment.
 | pip-compile-hashes     | `bool`      | Whether to generate hashes in the lockfile. Defaults to `false`.                                                                      |
 | pip-compile-verbose    | `bool`      | Set to `true` to run `pip-compile` in verbose mode instead of quiet mode, set to `false` to silence warnings                          |
 | pip-compile-args       | `list[str]` | Additional command-line arguments to pass to `pip-compile`                                                                            |
+
+#### Installing Lockfiles
+
+| name                     | type        | description                                                                                    |
+| ------------------------ | ----------- | ---------------------------------------------------------------------------------------------- |
+| pip-compile-installer    | `str`       | Whether to use `pip` or `pip-sync` to install dependencies into the project. Defaults to `pip` |
+| pip-compile-install-args | `list[str]` | Additional command-line arguments to pass to `pip-compile-installer`                           |
 
 #### Examples
 
@@ -268,6 +280,61 @@ Optionally, if you would like to silence any warnings set the `pip-compile-verbo
     [envs.<envName>]
     type = "pip-compile"
     pip-compile-verbose = true
+    ```
+
+##### pip-compile-installer
+
+Whether to use [pip] or [pip-sync] to install dependencies into the project. Defaults to `pip`.
+When you choose the `pip` option the plugin will run `pip install -r {lockfile}` under the hood
+to install the dependencies. When you choose the `pip-sync` option `pip-sync {lockfile}` is invoked
+by the plugin.
+
+The key difference between these options is that `pip-sync` will uninstall any packages that are
+not in the lockfile and remove them from your environment. `pip-sync` is useful if you want to ensure
+that your environment is exactly the same as the lockfile. If the environment should be used
+across different Python versions and platforms `pip` is the safer option to use.
+
+-   **_pyproject.toml_**
+
+    ```toml
+    [tool.hatch.envs.<envName>]
+    type = "pip-compile"
+    pip-compile-installer = "pip-sync"
+    ```
+
+-   **_hatch.toml_**
+
+    ```toml
+    [envs.<envName>]
+    type = "pip-compile"
+    pip-compile-installer = "pip-sync"
+    ```
+
+##### pip-compile-install-args
+
+Extra arguments to pass to `pip-compile-installer`. For example, if you'd like to use `pip` as the
+installer but want to pass the `--no-deps` flag to `pip install` you can do so with this option:
+
+-   **_pyproject.toml_**
+
+    ```toml
+    [tool.hatch.envs.<envName>]
+    type = "pip-compile"
+    pip-compile-installer = "pip"
+    pip-compile-install-args = [
+        "--no-deps"
+    ]
+    ```
+
+-   **_hatch.toml_**
+
+    ```toml
+    [envs.<envName>]
+    type = "pip-compile"
+    pip-compile-installer = "pip"
+    pip-compile-install-args = [
+        "--no-deps"
+    ]
     ```
 
 ## Upgrading Dependencies

--- a/hatch_pip_compile/installer.py
+++ b/hatch_pip_compile/installer.py
@@ -117,6 +117,7 @@ class PipSyncInstaller(PluginInstaller):
         3) (re)install project
         """
         with self.environment.safe_activation():
+            self.environment.run_pip_compile()
             self.install_dependencies()
         if not self.environment.skip_install:
             if self.environment.dev_mode:

--- a/hatch_pip_compile/installer.py
+++ b/hatch_pip_compile/installer.py
@@ -66,7 +66,6 @@ class PipInstaller(PluginInstaller):
         Install the dependencies with `pip`
         """
         with self.environment.safe_activation():
-            self.environment.run_pip_compile()
             if not self.environment.piptools_lock_file.exists():
                 return
             extra_args = self.environment.config.get("pip-compile-install-args", [])
@@ -118,7 +117,6 @@ class PipSyncInstaller(PluginInstaller):
         3) (re)install project
         """
         with self.environment.safe_activation():
-            self.environment.run_pip_compile()
             self.install_dependencies()
         if not self.environment.skip_install:
             if self.environment.dev_mode:

--- a/hatch_pip_compile/installer.py
+++ b/hatch_pip_compile/installer.py
@@ -1,0 +1,187 @@
+"""
+Package + Dependency Installers
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from hatchling.dep.core import dependencies_in_sync
+from packaging.requirements import Requirement
+
+if TYPE_CHECKING:
+    from hatch_pip_compile.plugin import PipCompileEnvironment
+
+
+@dataclass
+class PluginInstaller(ABC):
+    """
+    Package Installer for the plugin
+
+    This abstract base class is used to define the interface for
+    how the plugin should install packages and dependencies.
+    """
+
+    environment: "PipCompileEnvironment"
+
+    @abstractmethod
+    def install_dependencies(self) -> None:
+        """
+        Install the dependencies
+        """
+
+    def sync_dependencies(self) -> None:
+        """
+        Sync the dependencies - same as `install_dependencies`
+        """
+        self.install_dependencies()
+
+    def full_install(self) -> None:
+        """
+        Run the end-to-end install process
+        """
+        self.install_dependencies()
+
+    def run_pip_compile(self) -> None:
+        """
+        Run pip-compile if necessary
+        """
+        if not self.environment.lockfile_up_to_date:
+            self.install_pip_tools()
+            if self.environment.piptools_lock_file.exists():
+                _ = self.environment.piptools_lock.compare_python_versions(
+                    verbose=self.environment.config.get("pip-compile-verbose", None)
+                )
+            self.environment.pip_compile_cli()
+
+    def install_project(self) -> None:
+        """
+        Install the project (`--no-deps`)
+        """
+        with self.environment.safe_activation():
+            self.environment.platform.check_command(
+                self.environment.construct_pip_install_command(
+                    args=["--no-deps", str(self.environment.root)]
+                )
+            )
+
+    def install_project_dev_mode(self) -> None:
+        """
+        Install the project in editable mode (`--no-deps`)
+        """
+        with self.environment.safe_activation():
+            self.environment.platform.check_command(
+                self.environment.construct_pip_install_command(
+                    args=["--no-deps", "--editable", str(self.environment.root)]
+                )
+            )
+
+    def install_pip_tools(self) -> None:
+        """
+        Install pip-tools (if not already installed)
+        """
+        with self.environment.safe_activation():
+            in_sync = dependencies_in_sync(
+                requirements=[Requirement("pip-tools")],
+                sys_path=self.environment.virtual_env.sys_path,
+                environment=self.environment.virtual_env.environment,
+            )
+            if not in_sync:
+                self.environment.platform.check_command(
+                    self.environment.construct_pip_install_command(["pip-tools"])
+                )
+
+
+class PipInstaller(PluginInstaller):
+    """
+    Plugin Installer for `pip`
+    """
+
+    def install_dependencies(self) -> None:
+        """
+        Install the dependencies with `pip`
+        """
+        with self.environment.safe_activation():
+            self.run_pip_compile()
+            if not self.environment.piptools_lock_file.exists():
+                return
+            extra_args = self.environment.config.get("pip-compile-install-args", [])
+            args = [*extra_args, "--requirement", str(self.environment.piptools_lock_file)]
+            install_command = self.environment.construct_pip_install_command(args=args)
+            self.environment.virtual_env.platform.check_command(install_command)
+
+
+class PipSyncInstaller(PluginInstaller):
+    """
+    Plugin Installer for `pip-sync`
+    """
+
+    def install_dependencies(self) -> None:
+        """
+        Install the dependencies with `pip-sync`
+
+        In the event that there are no dependencies, pip-sync will
+        uninstall everything in the environment before deleting the
+        lockfile.
+        """
+        self.install_pip_tools()
+        cmd = [
+            self.environment.virtual_env.python_info.executable,
+            "-m",
+            "piptools",
+            "sync",
+            "--verbose"
+            if self.environment.config.get("pip-compile-verbose", None) is True
+            else "--quiet",
+            "--python-executable",
+            str(self.environment.virtual_env.python_info.executable),
+        ]
+        if not self.environment.dependencies:
+            self.environment.piptools_lock_file.write_text("")
+        extra_args = self.environment.config.get("pip-compile-install-args", [])
+        cmd.extend(extra_args)
+        cmd.append(str(self.environment.piptools_lock_file))
+        self.environment.virtual_env.platform.check_command(cmd)
+        if not self.environment.dependencies:
+            self.environment.piptools_lock_file.unlink()
+
+    def full_install(self) -> None:
+        """
+        Run the full install process
+
+        1) Run pip-compile (if necessary)
+        2) Run pip-sync
+        3) (re)install project
+        """
+        with self.environment.safe_activation():
+            self.run_pip_compile()
+            self.install_dependencies()
+        if not self.environment.skip_install:
+            if self.environment.dev_mode:
+                super().install_project_dev_mode()
+            else:
+                super().install_project()
+
+    def sync_dependencies(self):
+        """
+        Sync dependencies
+        """
+        self.full_install()
+
+    def install_project(self):
+        """
+        Install the project the first time
+
+        The same implementation as `full_install`
+        due to the way `pip-sync` uninstalls our root package
+        """
+        self.full_install()
+
+    def install_project_dev_mode(self):
+        """
+        Install the project the first time in dev mode
+
+        The same implementation as `full_install`
+        due to the way `pip-sync` uninstalls our root package
+        """
+        self.full_install()

--- a/hatch_pip_compile/installer.py
+++ b/hatch_pip_compile/installer.py
@@ -36,12 +36,6 @@ class PluginInstaller(ABC):
         """
         self.install_dependencies()
 
-    def full_install(self) -> None:
-        """
-        Run the end-to-end install process
-        """
-        self.install_dependencies()
-
     def run_pip_compile(self) -> None:
         """
         Run pip-compile if necessary
@@ -145,7 +139,7 @@ class PipSyncInstaller(PluginInstaller):
         if not self.environment.dependencies:
             self.environment.piptools_lock_file.unlink()
 
-    def full_install(self) -> None:
+    def _full_install(self) -> None:
         """
         Run the full install process
 
@@ -166,22 +160,22 @@ class PipSyncInstaller(PluginInstaller):
         """
         Sync dependencies
         """
-        self.full_install()
+        self._full_install()
 
     def install_project(self):
         """
         Install the project the first time
 
-        The same implementation as `full_install`
+        The same implementation as `_full_install`
         due to the way `pip-sync` uninstalls our root package
         """
-        self.full_install()
+        self._full_install()
 
     def install_project_dev_mode(self):
         """
         Install the project the first time in dev mode
 
-        The same implementation as `full_install`
+        The same implementation as `_full_install`
         due to the way `pip-sync` uninstalls our root package
         """
-        self.full_install()
+        self._full_install()

--- a/hatch_pip_compile/plugin.py
+++ b/hatch_pip_compile/plugin.py
@@ -243,6 +243,7 @@ class PipCompileEnvironment(VirtualEnvironment):
         """
         Sync dependencies
         """
+        self.run_pip_compile()
         self.installer.sync_dependencies()
 
     @property

--- a/hatch_pip_compile/plugin.py
+++ b/hatch_pip_compile/plugin.py
@@ -89,6 +89,9 @@ class PipCompileEnvironment(VirtualEnvironment):
         """
         Run pip-compile
         """
+        if not self.dependencies:
+            self._piptools_lock_file.unlink(missing_ok=True)
+            return
         no_compile = bool(os.getenv("PIP_COMPILE_DISABLE"))
         if no_compile:
             msg = "hatch-pip-compile is disabled but attempted to run a lockfile update."
@@ -313,6 +316,8 @@ class PipCompileEnvironmentWithPipInstall(PipCompileEnvironment):
                     self.construct_pip_install_command(["pip-tools"])
                 )
                 self._pip_compile_cli()
+            if not self._piptools_lock_file.exists():
+                return
             extra_args = self.config.get("pip-compile-install-args", [])
             args = [*extra_args, "--requirement", str(self._piptools_lock_file)]
             install_command = self.construct_pip_install_command(args=args)

--- a/hatch_pip_compile/plugin.py
+++ b/hatch_pip_compile/plugin.py
@@ -107,12 +107,13 @@ class PipCompileEnvironment(VirtualEnvironment):
         Run pip-compile if necessary
         """
         if not self.lockfile_up_to_date:
-            self.install_pip_tools()
-            if self.piptools_lock_file.exists():
-                _ = self.piptools_lock.compare_python_versions(
-                    verbose=self.config.get("pip-compile-verbose", None)
-                )
-            self.pip_compile_cli()
+            with self.safe_activation():
+                self.install_pip_tools()
+                if self.piptools_lock_file.exists():
+                    _ = self.piptools_lock.compare_python_versions(
+                        verbose=self.config.get("pip-compile-verbose", None)
+                    )
+                self.pip_compile_cli()
 
     def pip_compile_cli(self) -> None:
         """

--- a/hatch_pip_compile/plugin.py
+++ b/hatch_pip_compile/plugin.py
@@ -293,14 +293,14 @@ class PipCompileEnvironment(VirtualEnvironment):
             Whether the constraints file is valid
         """
         if not constraints_file.exists():
-            self.constraint_env.installer.full_install()
+            self.constraint_env.installer.run_pip_compile()
             return False
         else:
             up_to_date = environment.piptools_lock.compare_requirements(
                 requirements=environment.dependencies_complex
             )
             if not up_to_date:
-                self.constraint_env.installer.full_install()
+                self.constraint_env.installer.run_pip_compile()
                 return False
         return True
 

--- a/hatch_pip_compile/plugin.py
+++ b/hatch_pip_compile/plugin.py
@@ -38,7 +38,7 @@ class PipCompileEnvironment(VirtualEnvironment):
         """
         return f"<{self.__class__.__name__} - {self.name}>"
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         """
         Initialize PipCompileEnvironment with extra attributes
         """

--- a/hatch_pip_compile/plugin.py
+++ b/hatch_pip_compile/plugin.py
@@ -82,6 +82,7 @@ class PipCompileEnvironment(VirtualEnvironment):
             "pip-compile-args": List[str],
             "pip-compile-constraint": str,
             "pip-compile-installer": str,
+            "pip-compile-install-args": List[str],
         }
 
     def _pip_compile_cli(self) -> None:
@@ -365,10 +366,12 @@ class PipCompileEnvironmentWithPipSync(PipCompileEnvironment):
             "--verbose" if self.config.get("pip-compile-verbose", None) is True else "--quiet",
             "--python-executable",
             str(self.virtual_env.python_info.executable),
-            str(self._piptools_lock_file),
         ]
         if not self.dependencies:
             self._piptools_lock_file.write_text("")
+        extra_args = self.config.get("pip-compile-install-args", [])
+        cmd.extend(extra_args)
+        cmd.append(str(self._piptools_lock_file))
         self.virtual_env.platform.check_command(cmd)
         if not self.dependencies:
             self._piptools_lock_file.unlink()

--- a/hatch_pip_compile/plugin.py
+++ b/hatch_pip_compile/plugin.py
@@ -139,6 +139,18 @@ class PipCompileEnvironment(VirtualEnvironment):
             shutil.move(output_file, self.piptools_lock_file)
         self.lockfile_up_to_date = True
 
+    def install_project(self) -> None:
+        """
+        Install the project (`--no-deps`)
+        """
+        self.installer.install_project()
+
+    def install_project_dev_mode(self) -> None:
+        """
+        Install the project in editable mode (`--no-deps`)
+        """
+        self.installer.install_project_dev_mode()
+
     @functools.cached_property
     def lockfile_up_to_date(self) -> bool:
         """
@@ -199,6 +211,12 @@ class PipCompileEnvironment(VirtualEnvironment):
             return False
         else:
             return super().dependencies_in_sync()
+
+    def sync_dependencies(self) -> None:
+        """
+        Sync dependencies
+        """
+        self.installer.sync_dependencies()
 
     @property
     def piptools_constraints_file(self) -> Optional[pathlib.Path]:
@@ -292,21 +310,3 @@ class PipCompileEnvironment(VirtualEnvironment):
         Get the environment dictionary
         """
         return self.metadata.hatch.config.get("envs", {})
-
-    def install_project(self) -> None:
-        """
-        Install the project (`--no-deps`)
-        """
-        self.installer.install_project()
-
-    def install_project_dev_mode(self) -> None:
-        """
-        Install the project in editable mode (`--no-deps`)
-        """
-        self.installer.install_project_dev_mode()
-
-    def sync_dependencies(self) -> None:
-        """
-        Sync dependencies
-        """
-        self.installer.sync_dependencies()

--- a/hatch_pip_compile/plugin.py
+++ b/hatch_pip_compile/plugin.py
@@ -282,6 +282,24 @@ class PipCompileEnvironment(VirtualEnvironment):
         """
         return self.metadata.hatch.config.get("envs", {})
 
+    def install_project(self) -> None:
+        """
+        Install the project (`--no-deps`)
+        """
+        with self.safe_activation():
+            self.platform.check_command(
+                self.construct_pip_install_command(args=["--no-deps", str(self.root)])
+            )
+
+    def install_project_dev_mode(self) -> None:
+        """
+        Install the project in editable mode (`--no-deps`)
+        """
+        with self.safe_activation():
+            self.platform.check_command(
+                self.construct_pip_install_command(args=["--no-deps", "--editable", str(self.root)])
+            )
+
 
 class PipCompileEnvironmentWithPipInstall(PipCompileEnvironment):
     def sync_dependencies(self) -> None:


### PR DESCRIPTION
## Changes
- New `installer` class
  - Changes default behavior to run pip install -r lockfile.txt instead of pip-sync lockfile.txt
    - Makes this a configurable option, pip-compile-installer
  - Only forces project reinstall when using pip-sync option
  - Deletes lockfile if no dependencies with both pip and pip-sync options

Yet another alternative to #30 

Closes #29 