### PR TITLE
🧪 more tests

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -3,7 +3,7 @@
 ## Environment Setup
 
 > TIP: **pipx**
-> 
+>
 > This documentaion uses [pipx] to
 > install and manage non-project command line tools like `hatch` and
 > `pre-commit`. If you don't already have `pipx` installed, make sure to

--- a/hatch_pip_compile/hooks.py
+++ b/hatch_pip_compile/hooks.py
@@ -2,11 +2,16 @@
 Hatch Plugin Registration
 """
 
+from typing import Type
+
 from hatchling.plugin import hookimpl
 
 from hatch_pip_compile.plugin import PipCompileEnvironment
 
 
 @hookimpl
-def hatch_register_environment():
+def hatch_register_environment() -> Type[PipCompileEnvironment]:
+    """
+    Register the PipCompileEnvironment plugin with Hatch
+    """
     return PipCompileEnvironment

--- a/hatch_pip_compile/plugin.py
+++ b/hatch_pip_compile/plugin.py
@@ -81,7 +81,7 @@ class PipCompileEnvironment(VirtualEnvironment):
         """
         Get option types
         """
-        return {
+        return {  # pragma: no cover
             "lock-filename": str,
             "pip-compile-hashes": bool,
             "pip-compile-args": List[str],
@@ -122,6 +122,7 @@ class PipCompileEnvironment(VirtualEnvironment):
         """
         if not self.dependencies:
             self.piptools_lock_file.unlink(missing_ok=True)
+            self.lockfile_up_to_date = True
             return
         no_compile = bool(os.getenv("PIP_COMPILE_DISABLE"))
         if no_compile:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,8 @@ python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 [tool.hatch.envs.test]
 dependencies = [
   "pytest",
-  "pytest-cov"
+  "pytest-cov",
+  "tomlkit"
 ]
 
 [tool.hatch.envs.test.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,8 @@ show_missing = true
 [tool.coverage.run]
 branch = true
 omit = [
-  "hatch_pip_compile/__about__.py"
+  "hatch_pip_compile/__about__.py",
+  "hatch_pip_compile/hooks.py"
 ]
 parallel = true
 source_pkgs = ["hatch_pip_compile", "tests"]
@@ -196,8 +197,8 @@ ban-relative-imports = "all"
 known-first-party = ["hatch_pip_compile"]
 
 [tool.ruff.per-file-ignores]
-# Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+# Tests can use magic values, assertions, relative imports, and unused arguments
+"tests/**/*" = ["PLR2004", "S101", "TID252", "ARG001"]
 
 [tool.ruff.pydocstyle]
 convention = "numpy"

--- a/requirements/requirements-matrix.py3.10.txt
+++ b/requirements/requirements-matrix.py3.10.txt
@@ -5,6 +5,7 @@
 #
 # - pytest
 # - pytest-cov
+# - tomlkit
 # - hatch
 #
 
@@ -165,6 +166,7 @@ tomli-w==1.0.0
 tomlkit==0.12.3
     # via
     #   -c requirements.txt
+    #   hatch.envs.matrix.py3.10
     #   hatch
 trove-classifiers==2023.11.29
     # via

--- a/requirements/requirements-matrix.py3.11.txt
+++ b/requirements/requirements-matrix.py3.11.txt
@@ -5,6 +5,7 @@
 #
 # - pytest
 # - pytest-cov
+# - tomlkit
 # - hatch
 #
 
@@ -156,6 +157,7 @@ tomli-w==1.0.0
 tomlkit==0.12.3
     # via
     #   -c requirements.txt
+    #   hatch.envs.matrix.py3.11
     #   hatch
 trove-classifiers==2023.11.29
     # via

--- a/requirements/requirements-matrix.py3.12.txt
+++ b/requirements/requirements-matrix.py3.12.txt
@@ -5,6 +5,7 @@
 #
 # - pytest
 # - pytest-cov
+# - tomlkit
 # - hatch
 #
 
@@ -152,6 +153,7 @@ tomli-w==1.0.0
 tomlkit==0.12.3
     # via
     #   -c requirements.txt
+    #   hatch.envs.matrix.py3.12
     #   hatch
 trove-classifiers==2023.11.29
     # via

--- a/requirements/requirements-matrix.py3.8.txt
+++ b/requirements/requirements-matrix.py3.8.txt
@@ -5,6 +5,7 @@
 #
 # - pytest
 # - pytest-cov
+# - tomlkit
 # - hatch
 #
 
@@ -167,6 +168,7 @@ tomli-w==1.0.0
 tomlkit==0.12.3
     # via
     #   -c requirements.txt
+    #   hatch.envs.matrix.py3.8
     #   hatch
 trove-classifiers==2023.11.29
     # via

--- a/requirements/requirements-matrix.py3.9.txt
+++ b/requirements/requirements-matrix.py3.9.txt
@@ -5,6 +5,7 @@
 #
 # - pytest
 # - pytest-cov
+# - tomlkit
 # - hatch
 #
 
@@ -23,7 +24,9 @@ click==8.1.7
     #   hatch
     #   userpath
 coverage==7.3.2
-    # via pytest-cov
+    # via
+    #   coverage
+    #   pytest-cov
 distlib==0.3.7
     # via
     #   -c requirements.txt
@@ -163,6 +166,7 @@ tomli-w==1.0.0
 tomlkit==0.12.3
     # via
     #   -c requirements.txt
+    #   hatch.envs.matrix.py3.9
     #   hatch
 trove-classifiers==2023.11.29
     # via

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -5,6 +5,7 @@
 #
 # - pytest
 # - pytest-cov
+# - tomlkit
 # - hatch
 #
 
@@ -177,6 +178,7 @@ tomli-w==1.0.0
 tomlkit==0.12.3
     # via
     #   -c requirements.txt
+    #   hatch.envs.test
     #   hatch
 trove-classifiers==2023.11.29
     # via

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 
 import pytest
 import tomlkit
+from hatch.cli.application import Application
 from hatch.config.constants import AppEnvVars, ConfigEnvVars, PublishEnvVars
 from hatch.project.core import Project
 from hatch.utils.fs import Path, temp_directory
@@ -89,6 +90,7 @@ class PipCompileFixture:
     platform: Platform
     isolated_data_dir: pathlib.Path
 
+    application: Application = field(init=False)
     default_environment: PipCompileEnvironment = field(init=False)
     test_environment: PipCompileEnvironment = field(init=False)
 
@@ -96,6 +98,12 @@ class PipCompileFixture:
         """
         Post Init
         """
+        self.application = Application(
+            exit_func=lambda x: None,  # noqa: ARG005
+            verbosity=0,
+            interactive=False,
+            enable_color=False,
+        )
         self.default_environment = self.reload_environment("default")
         self.test_environment = self.reload_environment("test")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import pathlib
 import shutil
 from dataclasses import dataclass, field
 from subprocess import CompletedProcess
-from typing import Generator
+from typing import Dict, Generator, Type
 from unittest.mock import patch
 
 import pytest
@@ -17,11 +17,12 @@ from hatch.project.core import Project
 from hatch.utils.fs import Path, temp_directory
 from hatch.utils.platform import Platform
 
+from hatch_pip_compile.installer import PipInstaller, PipSyncInstaller, PluginInstaller
 from hatch_pip_compile.plugin import PipCompileEnvironment
 
 
 @pytest.fixture
-def mock_check_command():
+def mock_check_command() -> Generator[patch, None, None]:
     """
     Disable the `plugin_check_command` for testing
     """
@@ -140,3 +141,14 @@ def pip_compile(
         platform=platform,
         isolated_data_dir=isolated_data_dir,
     )
+
+
+@pytest.fixture
+def installer_dict() -> Dict[str, Type[PluginInstaller]]:
+    """
+    Installer dictionary for parametrized tests
+    """
+    return {
+        "pip": PipInstaller,
+        "pip-sync": PipSyncInstaller,
+    }

--- a/tests/data/pyproject.toml
+++ b/tests/data/pyproject.toml
@@ -17,7 +17,7 @@ requires-python = ">=3.8"
 version = "0.1.0"
 
 [tool.hatch.envs.default]
-path = ".venv/hatch-pip-compile"
+path = ".venv/hatch-pip-compile-test"
 pip-compile-constraint = "default"
 type = "pip-compile"
 

--- a/tests/data/pyproject.toml
+++ b/tests/data/pyproject.toml
@@ -9,17 +9,15 @@ authors = [
 dependencies = [
   "hatch"
 ]
-description = "hatch plugin to use pip-compile to manage project dependencies"
+description = "testing hatch-pip-compile"
 license = "MIT"
-name = "hatch-pip-compile"
+name = "hatch-pip-compile-test"
 readme = "README.md"
 requires-python = ">=3.8"
 version = "0.1.0"
 
-[tool.hatch.env]
-requires = ["hatch-pip-compile"]
-
 [tool.hatch.envs.default]
+path = ".venv/hatch-pip-compile"
 pip-compile-constraint = "default"
 type = "pip-compile"
 
@@ -29,9 +27,11 @@ dependencies = [
   "ruff~=0.1.4"
 ]
 detached = true
+path = ".venv/lint"
 
 [tool.hatch.envs.test]
 dependencies = [
   "pytest",
   "pytest-cov"
 ]
+path = ".venv/test"

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -3,7 +3,7 @@ Installation Tests
 """
 
 from typing import Dict, Type
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 
@@ -12,7 +12,6 @@ from hatch_pip_compile.installer import PluginInstaller
 from tests.conftest import PipCompileFixture
 
 
-@patch("hatch_pip_compile.plugin.PipCompileEnvironment.plugin_check_command")
 def test_pip_install_dependencies(mock_check_command: Mock, pip_compile: PipCompileFixture) -> None:
     """
     Assert the `pip` installation command is called with the expected arguments

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -5,21 +5,23 @@ Installation Tests
 from subprocess import CompletedProcess
 from unittest.mock import Mock, patch
 
-from hatch_pip_compile.plugin import PipCompileEnvironment
+import pytest
+
+from hatch_pip_compile.exceptions import HatchPipCompileError
+from hatch_pip_compile.installer import PipInstaller, PipSyncInstaller
+from tests.conftest import PipCompileFixture
 
 
 @patch("hatch_pip_compile.plugin.PipCompileEnvironment.plugin_check_command")
-def test_pip_install_dependencies(
-    mock_check_command: Mock, default_environment: PipCompileEnvironment
-) -> None:
+def test_pip_install_dependencies(mock_check_command: Mock, pip_compile: PipCompileFixture) -> None:
     """
     Assert the `pip` installation command is called with the expected arguments
     """
     mock_check_command.return_value = CompletedProcess(
         args=[], returncode=0, stdout=b"", stderr=b""
     )
-    default_environment.create()
-    default_environment.installer.install_dependencies()
+    pip_compile.default_environment.create()
+    pip_compile.default_environment.installer.install_dependencies()
     expected_call = [
         "python",
         "-u",
@@ -33,3 +35,33 @@ def test_pip_install_dependencies(
     ]
     call_args = list(mock_check_command.call_args)[0][0][:-1]
     assert call_args == expected_call
+
+
+def test_installer_pip(pip_compile: PipCompileFixture) -> None:
+    """
+    Test that the `pip` installer is used when configured
+    """
+    pip_compile.toml_doc["tool"]["hatch"]["envs"]["default"]["pip-compile-installer"] = "pip"
+    pip_compile.update_pyproject()
+    updated_environment = pip_compile.reload_environment("default")
+    assert isinstance(updated_environment.installer, PipInstaller)
+
+
+def test_installer_pip_sync(pip_compile: PipCompileFixture) -> None:
+    """
+    Test that the `pip-sync` installer is used when configured
+    """
+    pip_compile.toml_doc["tool"]["hatch"]["envs"]["default"]["pip-compile-installer"] = "pip-sync"
+    pip_compile.update_pyproject()
+    updated_environment = pip_compile.reload_environment("default")
+    assert isinstance(updated_environment.installer, PipSyncInstaller)
+
+
+def test_installer_unknown(pip_compile: PipCompileFixture) -> None:
+    """
+    Test that an exception is raised when an unknown installer is configured
+    """
+    pip_compile.toml_doc["tool"]["hatch"]["envs"]["default"]["pip-compile-installer"] = "unknown"
+    pip_compile.update_pyproject()
+    with pytest.raises(HatchPipCompileError):
+        _ = pip_compile.reload_environment("default")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -52,7 +52,7 @@ def test_delete_dependencies(
     assert updated_environment.lockfile_up_to_date is False
     pip_compile.application.prepare_environment(environment=updated_environment)
     assert updated_environment.lockfile_up_to_date is True
-    assert (pip_compile.isolation / ".venv" / "hatch-pip-compile").exists()
+    assert (pip_compile.isolation / ".venv" / "hatch-pip-compile-test").exists()
     assert updated_environment.dependencies == []
     assert updated_environment.piptools_lock_file.exists() is False
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,74 @@
+"""
+Integration Tests
+
+These tests are "integration" tests in that they test the
+interaction between the various components of hatch-pip-compile
+and external tools (pip-tools / pip).
+"""
+
+from hatch_pip_compile.installer import PipSyncInstaller
+from tests.conftest import PipCompileFixture
+
+
+def test_new_dependency(pip_compile: PipCompileFixture) -> None:
+    """
+    Test adding a new dependency
+    """
+    original_lockfile_contents = pip_compile.default_environment.piptools_lock_file.read_text()
+    pip_compile.toml_doc["project"]["dependencies"] = ["requests"]
+    pip_compile.update_pyproject()
+    updated_environment = pip_compile.reload_environment("default")
+    assert updated_environment.dependencies == ["requests"]
+    assert updated_environment.lockfile_up_to_date is False
+    updated_environment.sync_dependencies()
+    assert updated_environment.lockfile_up_to_date is True
+    new_lockfile_contents = pip_compile.default_environment.piptools_lock_file.read_text()
+    assert new_lockfile_contents != original_lockfile_contents
+
+
+def test_new_dependency_pip_sync(pip_compile: PipCompileFixture) -> None:
+    """
+    Test adding a new dependency with pip-sync
+    """
+    original_lockfile_contents = pip_compile.default_environment.piptools_lock_file.read_text()
+    pip_compile.toml_doc["project"]["dependencies"] = ["requests"]
+    pip_compile.toml_doc["tool"]["hatch"]["envs"]["default"]["pip-compile-installer"] = "pip-sync"
+    pip_compile.update_pyproject()
+    updated_environment = pip_compile.reload_environment("default")
+    assert isinstance(updated_environment.installer, PipSyncInstaller)
+    updated_environment.sync_dependencies()
+    assert updated_environment.lockfile_up_to_date is True
+    new_lockfile_contents = pip_compile.default_environment.piptools_lock_file.read_text()
+    assert new_lockfile_contents != original_lockfile_contents
+
+
+def test_delete_dependencies(pip_compile: PipCompileFixture) -> None:
+    """
+    Test deleting all dependencies also deletes the lockfile
+    """
+    pip_compile.toml_doc["project"]["dependencies"] = []
+    pip_compile.update_pyproject()
+    updated_environment = pip_compile.reload_environment("default")
+    assert updated_environment.dependencies == []
+    assert updated_environment.lockfile_up_to_date is False
+    updated_environment.create()
+    updated_environment.sync_dependencies()
+    assert updated_environment.lockfile_up_to_date is True
+    assert (pip_compile.isolation / ".venv" / "hatch-pip-compile").exists()
+    assert updated_environment.dependencies == []
+    assert updated_environment.piptools_lock_file.exists() is False
+
+
+def test_create_constraint_environment(pip_compile: PipCompileFixture) -> None:
+    """
+    Syncing an environment with a constraint env also syncs the constraint env
+    """
+    default_lockfile_contents = pip_compile.default_environment.piptools_lock_file.read_text()
+    pip_compile.toml_doc["project"]["dependencies"] = ["requests"]
+    pip_compile.update_pyproject()
+    test_environment = pip_compile.reload_environment("test")
+    assert (  # this is the call that updates the constraint lockfile
+        test_environment.lockfile_up_to_date is False
+    )
+    new_lockfile_contents = pip_compile.default_environment.piptools_lock_file.read_text()
+    assert new_lockfile_contents != default_lockfile_contents

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,40 +6,34 @@ interaction between the various components of hatch-pip-compile
 and external tools (pip-tools / pip).
 """
 
-from hatch_pip_compile.installer import PipSyncInstaller
+from typing import Dict, Type
+
+import packaging.requirements
+import pytest
+
+from hatch_pip_compile.installer import PluginInstaller
 from tests.conftest import PipCompileFixture
 
 
-def test_new_dependency(pip_compile: PipCompileFixture) -> None:
+@pytest.mark.parametrize("installer", ["pip", "pip-sync"])
+def test_new_dependency(
+    installer: str, installer_dict: Dict[str, Type[PluginInstaller]], pip_compile: PipCompileFixture
+) -> None:
     """
     Test adding a new dependency
     """
-    original_lockfile_contents = pip_compile.default_environment.piptools_lock_file.read_text()
+    original_requirements = pip_compile.default_environment.piptools_lock.read_requirements()
+    assert original_requirements == [packaging.requirements.Requirement("hatch")]
     pip_compile.toml_doc["project"]["dependencies"] = ["requests"]
+    pip_compile.toml_doc["tool"]["hatch"]["envs"]["default"]["pip-compile-installer"] = installer
     pip_compile.update_pyproject()
     updated_environment = pip_compile.reload_environment("default")
+    assert isinstance(updated_environment.installer, installer_dict[installer])
     assert updated_environment.dependencies == ["requests"]
-    assert updated_environment.lockfile_up_to_date is False
     updated_environment.sync_dependencies()
     assert updated_environment.lockfile_up_to_date is True
-    new_lockfile_contents = pip_compile.default_environment.piptools_lock_file.read_text()
-    assert new_lockfile_contents != original_lockfile_contents
-
-
-def test_new_dependency_pip_sync(pip_compile: PipCompileFixture) -> None:
-    """
-    Test adding a new dependency with pip-sync
-    """
-    original_lockfile_contents = pip_compile.default_environment.piptools_lock_file.read_text()
-    pip_compile.toml_doc["project"]["dependencies"] = ["requests"]
-    pip_compile.toml_doc["tool"]["hatch"]["envs"]["default"]["pip-compile-installer"] = "pip-sync"
-    pip_compile.update_pyproject()
-    updated_environment = pip_compile.reload_environment("default")
-    assert isinstance(updated_environment.installer, PipSyncInstaller)
-    updated_environment.sync_dependencies()
-    assert updated_environment.lockfile_up_to_date is True
-    new_lockfile_contents = pip_compile.default_environment.piptools_lock_file.read_text()
-    assert new_lockfile_contents != original_lockfile_contents
+    new_lockfile_requirements = pip_compile.default_environment.piptools_lock.read_requirements()
+    assert new_lockfile_requirements == [packaging.requirements.Requirement("requests")]
 
 
 def test_delete_dependencies(pip_compile: PipCompileFixture) -> None:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -30,7 +30,7 @@ def test_new_dependency(
     updated_environment = pip_compile.reload_environment("default")
     assert isinstance(updated_environment.installer, installer_dict[installer])
     assert updated_environment.dependencies == ["requests"]
-    updated_environment.sync_dependencies()
+    pip_compile.application.prepare_environment(environment=updated_environment)
     assert updated_environment.lockfile_up_to_date is True
     new_lockfile_requirements = pip_compile.default_environment.piptools_lock.read_requirements()
     assert new_lockfile_requirements == [packaging.requirements.Requirement("requests")]
@@ -50,8 +50,7 @@ def test_delete_dependencies(
     assert isinstance(updated_environment.installer, installer_dict[installer])
     assert updated_environment.dependencies == []
     assert updated_environment.lockfile_up_to_date is False
-    updated_environment.create()
-    updated_environment.sync_dependencies()
+    pip_compile.application.prepare_environment(environment=updated_environment)
     assert updated_environment.lockfile_up_to_date is True
     assert (pip_compile.isolation / ".venv" / "hatch-pip-compile").exists()
     assert updated_environment.dependencies == []
@@ -62,12 +61,11 @@ def test_create_constraint_environment(pip_compile: PipCompileFixture) -> None:
     """
     Syncing an environment with a constraint env also syncs the constraint env
     """
-    default_lockfile_contents = pip_compile.default_environment.piptools_lock_file.read_text()
+    original_requirements = pip_compile.default_environment.piptools_lock.read_requirements()
+    assert original_requirements == [packaging.requirements.Requirement("hatch")]
     pip_compile.toml_doc["project"]["dependencies"] = ["requests"]
     pip_compile.update_pyproject()
     test_environment = pip_compile.reload_environment("test")
-    assert (  # this is the call that updates the constraint lockfile
-        test_environment.lockfile_up_to_date is False
-    )
-    new_lockfile_contents = pip_compile.default_environment.piptools_lock_file.read_text()
-    assert new_lockfile_contents != default_lockfile_contents
+    pip_compile.application.prepare_environment(environment=test_environment)
+    new_lockfile_requirements = pip_compile.default_environment.piptools_lock.read_requirements()
+    assert new_lockfile_requirements == [packaging.requirements.Requirement("requests")]

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -2,54 +2,53 @@
 Testing the `lock` module
 """
 
-
 from packaging.requirements import Requirement
 from packaging.version import Version
 
-from hatch_pip_compile.plugin import PipCompileEnvironment
+from tests.conftest import PipCompileFixture
 
 
 def test_lockfile_python_version(
-    default_environment: PipCompileEnvironment,
-    test_environment: PipCompileEnvironment,
+    pip_compile: PipCompileFixture,
 ):
     """
     Test the expected Python version from the lockfiles
     """
-    assert default_environment.piptools_lock.lock_file_version == Version("3.11")
-    assert test_environment.piptools_lock.lock_file_version == Version("3.11")
+    assert pip_compile.default_environment.piptools_lock.lock_file_version == Version("3.11")
+    assert pip_compile.test_environment.piptools_lock.lock_file_version == Version("3.11")
 
 
 def test_lockfile_dependencies(
-    default_environment: PipCompileEnvironment,
-    test_environment: PipCompileEnvironment,
+    pip_compile: PipCompileFixture,
 ):
     """
     Test the expected dependencies from reading the lockfiles
     """
-    assert set(default_environment.piptools_lock.read_requirements()) == {Requirement("hatch")}
-    assert set(test_environment.piptools_lock.read_requirements()) == {
+    assert set(pip_compile.default_environment.piptools_lock.read_requirements()) == {
+        Requirement("hatch")
+    }
+    assert set(pip_compile.test_environment.piptools_lock.read_requirements()) == {
         Requirement("pytest"),
         Requirement("pytest-cov"),
         Requirement("hatch"),
     }
 
 
-def test_compare_requirements_match(default_environment: PipCompileEnvironment):
+def test_compare_requirements_match(pip_compile: PipCompileFixture):
     """
     Test the `compare_requirements` method with a match
     """
-    default_check = default_environment.piptools_lock.compare_requirements(
+    default_check = pip_compile.default_environment.piptools_lock.compare_requirements(
         requirements=[Requirement("hatch")],
     )
     assert default_check is True
 
 
-def test_compare_requirements_mismatch(test_environment: PipCompileEnvironment):
+def test_compare_requirements_mismatch(pip_compile: PipCompileFixture):
     """
     Test the `compare_requirements` method with a mismatch
     """
-    test_check = test_environment.piptools_lock.compare_requirements(
+    test_check = pip_compile.test_environment.piptools_lock.compare_requirements(
         requirements=[Requirement("hatch")],
     )
     assert test_check is False

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -140,3 +140,13 @@ def test_env_var_disabled(pip_compile: PipCompileFixture, monkeypatch: pytest.Mo
     monkeypatch.setenv("PIP_COMPILE_DISABLE", "1")
     with pytest.raises(HatchPipCompileError, match="attempted to run a lockfile update"):
         pip_compile.default_environment.pip_compile_cli()
+
+
+def test_constraint_env_self(pip_compile: PipCompileFixture) -> None:
+    """
+    Test the value of the constraint env b/w the default and test environments
+    """
+    assert (
+        pip_compile.default_environment.constraint_env.name == pip_compile.default_environment.name
+    )
+    assert pip_compile.test_environment.constraint_env.name == pip_compile.default_environment.name

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -12,7 +12,7 @@ from tests.conftest import PipCompileFixture
 
 def test_lockfile_path(
     pip_compile: PipCompileFixture,
-):
+) -> None:
     """
     Test the default lockfile paths
     """
@@ -28,7 +28,7 @@ def test_lockfile_path(
 
 def test_piptools_constraints_file(
     pip_compile: PipCompileFixture,
-):
+) -> None:
     """
     Test constraints paths
     """

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2,104 +2,92 @@
 Plugin tests.
 """
 
-from subprocess import CompletedProcess
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
-from hatch.utils.fs import Path
+import pytest
 
-from hatch_pip_compile.plugin import PipCompileEnvironment
+from hatch_pip_compile.exceptions import HatchPipCompileError
+from tests.conftest import PipCompileFixture
 
 
 def test_lockfile_path(
-    isolation: Path,
-    default_environment: PipCompileEnvironment,
-    test_environment: PipCompileEnvironment,
+    pip_compile: PipCompileFixture,
 ):
     """
     Test the default lockfile paths
     """
-    assert default_environment.piptools_lock_file == isolation / "requirements.txt"
     assert (
-        test_environment.piptools_lock_file == isolation / "requirements" / "requirements-test.txt"
+        pip_compile.default_environment.piptools_lock_file
+        == pip_compile.isolation / "requirements.txt"
+    )
+    assert (
+        pip_compile.test_environment.piptools_lock_file
+        == pip_compile.isolation / "requirements" / "requirements-test.txt"
     )
 
 
 def test_piptools_constraints_file(
-    default_environment: PipCompileEnvironment,
-    test_environment: PipCompileEnvironment,
+    pip_compile: PipCompileFixture,
 ):
     """
     Test constraints paths
     """
-    assert default_environment.piptools_constraints_file is None
-    assert test_environment.piptools_constraints_file == default_environment.piptools_lock_file
+    assert pip_compile.default_environment.piptools_constraints_file is None
+    assert (
+        pip_compile.test_environment.piptools_constraints_file
+        == pip_compile.default_environment.piptools_lock_file
+    )
 
 
-def test_expected_dependencies(
-    default_environment: PipCompileEnvironment,
-    test_environment: PipCompileEnvironment,
-):
+def test_expected_dependencies(pip_compile: PipCompileFixture) -> None:
     """
     Test expected dependencies from `PipCompileEnvironment`
     """
-    assert set(default_environment.dependencies) == {"hatch"}
-    assert set(test_environment.dependencies) == {"pytest", "pytest-cov", "hatch"}
+    assert set(pip_compile.default_environment.dependencies) == {"hatch"}
+    assert set(pip_compile.test_environment.dependencies) == {"pytest", "pytest-cov", "hatch"}
 
 
-def test_lockfile_up_to_date(
-    default_environment: PipCompileEnvironment,
-    test_environment: PipCompileEnvironment,
-):
+def test_lockfile_up_to_date(pip_compile: PipCompileFixture) -> None:
     """
     Test the prepared lockfiles are up-to-date
     """
-    assert default_environment.lockfile_up_to_date is True
-    assert test_environment.lockfile_up_to_date is True
+    assert pip_compile.default_environment.lockfile_up_to_date is True
+    assert pip_compile.test_environment.lockfile_up_to_date is True
 
 
-def test_lockfile_up_to_date_missing(
-    default_environment: PipCompileEnvironment,
-):
+def test_lockfile_up_to_date_missing(pip_compile: PipCompileFixture) -> None:
     """
     Test the `lockfile_up_to_date` property when the lockfile is missing
     """
-    default_environment.piptools_lock_file.unlink()
-    assert default_environment.lockfile_up_to_date is False
-    assert default_environment.dependencies_in_sync() is False
+    pip_compile.default_environment.piptools_lock_file.unlink()
+    assert pip_compile.default_environment.lockfile_up_to_date is False
+    assert pip_compile.default_environment.dependencies_in_sync() is False
 
 
-def test_lockfile_up_to_date_empty(
-    default_environment: PipCompileEnvironment,
-):
+def test_lockfile_up_to_date_empty(pip_compile: PipCompileFixture) -> None:
     """
     Test the `lockfile_up_to_date` property when the lockfile is empty
     """
-    default_environment.piptools_lock_file.write_text("")
-    assert default_environment.lockfile_up_to_date is False
-    assert default_environment.dependencies_in_sync() is False
+    pip_compile.default_environment.piptools_lock_file.write_text("")
+    assert pip_compile.default_environment.lockfile_up_to_date is False
+    assert pip_compile.default_environment.dependencies_in_sync() is False
 
 
-def test_lockfile_up_to_date_mismatch(
-    default_environment: PipCompileEnvironment,
-):
+def test_lockfile_up_to_date_mismatch(pip_compile: PipCompileFixture) -> None:
     """
     Test the `lockfile_up_to_date` property when the lockfile is mismatched
     """
-    lock_text = default_environment.piptools_lock_file.read_text()
+    lock_text = pip_compile.default_environment.piptools_lock_file.read_text()
     lock_text = lock_text.replace("# - hatch", "#")
-    default_environment.piptools_lock_file.write_text(lock_text)
-    assert default_environment.lockfile_up_to_date is False
+    pip_compile.default_environment.piptools_lock_file.write_text(lock_text)
+    assert pip_compile.default_environment.lockfile_up_to_date is False
 
 
-@patch("hatch_pip_compile.plugin.PipCompileEnvironment.plugin_check_command")
-def test_pip_compile_cli(mock_check_command: Mock, default_environment: PipCompileEnvironment):
+def test_pip_compile_cli(mock_check_command: Mock, pip_compile: PipCompileFixture) -> None:
     """
     Test the `pip_compile_cli` method is called with the expected arguments
     """
-    mock_check_command.return_value = CompletedProcess(
-        args=[], returncode=0, stdout=b"", stderr=b""
-    )
-    default_environment.pip_compile_cli()
+    pip_compile.default_environment.pip_compile_cli()
     expected_call = [
         "python",
         "-m",
@@ -113,3 +101,42 @@ def test_pip_compile_cli(mock_check_command: Mock, default_environment: PipCompi
     ]
     call_args = list(mock_check_command.call_args)[0][0][:-2]
     assert call_args == expected_call
+
+
+def test_environment_change(
+    pip_compile: PipCompileFixture,
+) -> None:
+    """
+    Override the `dependencies` property and assert the `lockfile_up_to_date` property is False
+    """
+    assert pip_compile.test_environment.lockfile_up_to_date is True
+    pip_compile.toml_doc["tool"]["hatch"]["envs"]["test"]["dependencies"] = ["requests"]
+    pip_compile.update_pyproject()
+    new_environment = pip_compile.reload_environment("test")
+    assert new_environment.dependencies == ["requests", "hatch"]
+    assert new_environment.lockfile_up_to_date is False
+
+
+def test_constraint_dependency_change(
+    pip_compile: PipCompileFixture, mock_check_command: Mock
+) -> None:
+    """
+    Update the constraint environment and assert it and its downstream environments are out-of-sync
+    """
+    assert pip_compile.default_environment.lockfile_up_to_date is True
+    assert pip_compile.test_environment.lockfile_up_to_date is True
+    pip_compile.toml_doc["tool"]["hatch"]["envs"]["default"]["dependencies"] = ["requests"]
+    pip_compile.update_pyproject()
+    new_default_env = pip_compile.reload_environment("default")
+    new_test_env = pip_compile.reload_environment("test")
+    assert new_default_env.lockfile_up_to_date is False
+    assert new_test_env.lockfile_up_to_date is False
+
+
+def test_env_var_disabled(pip_compile: PipCompileFixture, monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Test the `lockfile_up_to_date` property when the lockfile is empty
+    """
+    monkeypatch.setenv("PIP_COMPILE_DISABLE", "1")
+    with pytest.raises(HatchPipCompileError, match="attempted to run a lockfile update"):
+        pip_compile.default_environment.pip_compile_cli()


### PR DESCRIPTION
This PR includes a new all-in-one testing fixture, `pip_compile` (`PipCompileFixture`) that can be used throughout the tests. 

This PR also includes a number of new tests, including what I'm calling "integration tests" at `tests/test_integration.py`. These tests ultimately make calls to `pip-tools` / `pip` and create their own virtual environments inside the testing isolation temp dirs.

Closes #18 

