### PR TITLE
🐛 cross-platform hashes

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,7 +20,6 @@ on:
         - cron: 0 12 1 * *
 jobs:
     test-suite:
-        runs-on: ubuntu-latest
         strategy:
             fail-fast: true
             matrix:
@@ -31,6 +30,7 @@ jobs:
                           command: "matrix:cov",
                           matrix: "+py=3.12",
                           hatch_version: "1.0",
+                          os: ubuntu-latest,
                       }
                     - {
                           name: Python-3.11,
@@ -38,6 +38,7 @@ jobs:
                           command: "matrix:cov",
                           matrix: "+py=3.11",
                           hatch_version: "1.0",
+                          os: ubuntu-latest,
                       }
                     - {
                           name: Python-3.10,
@@ -45,6 +46,7 @@ jobs:
                           command: "matrix:cov",
                           matrix: "+py=3.10",
                           hatch_version: "1.0",
+                          os: ubuntu-latest,
                       }
                     - {
                           name: Python-3.9,
@@ -52,6 +54,7 @@ jobs:
                           command: "matrix:cov",
                           matrix: "+py=3.9",
                           hatch_version: "1.0",
+                          os: ubuntu-latest,
                       }
                     - {
                           name: Python-3.8,
@@ -59,6 +62,7 @@ jobs:
                           command: "matrix:cov",
                           matrix: "+py=3.8",
                           hatch_version: "1.0",
+                          os: ubuntu-latest,
                       }
                     - {
                           name: Hatch-1.7.x,
@@ -66,6 +70,7 @@ jobs:
                           command: "versions:cov",
                           matrix: "+version=1.7.x",
                           hatch_version: "1.7.0",
+                          os: ubuntu-latest,
                       }
                     - {
                           name: Hatch-1.8.x,
@@ -73,6 +78,7 @@ jobs:
                           command: "versions:cov",
                           matrix: "+version=1.8.x",
                           hatch_version: "1.8.0",
+                          os: ubuntu-latest,
                       }
                     - {
                           name: Hatch-1.9.x,
@@ -80,7 +86,17 @@ jobs:
                           command: "versions:cov",
                           matrix: "+version=1.9.x",
                           hatch_version: "1.9.0",
+                          os: ubuntu-latest,
                       }
+                    - {
+                          name: Hatch-Windows,
+                          python: "3.11",
+                          command: "matrix:cov",
+                          matrix: "+py=3.11",
+                          hatch_version: "1.0",
+                          os: windows-latest,
+                      }
+        runs-on: ${{ matrix.os }}
         concurrency:
             group: ${{ github.workflow }}-${{ matrix.name }}-${{ github.ref }}
             cancel-in-progress: true

--- a/docs/gen_pages.py
+++ b/docs/gen_pages.py
@@ -30,9 +30,7 @@ for path in sorted(source_code.rglob("*.py")):
 
     mkdocs_gen_files.set_edit_path(full_doc_path, path)
 
-
-with open("README.md") as in_file:
-    readme_content = in_file.read()
+readme_content = Path("README.md").read_text(encoding="utf-8")
 # Exclude parts that are between two exact `<!--skip-->` lines
 readme_content = "\n".join(readme_content.split("\n<!--skip-->\n")[::2])
 with mkdocs_gen_files.open("index.md", "w") as index_file:

--- a/hatch_pip_compile/lock.py
+++ b/hatch_pip_compile/lock.py
@@ -53,7 +53,9 @@ class PipCompileLock:
             lockfile_text,
         )
         if self.constraints_file is not None:
-            constraint_sha = hashlib.sha256(self.constraints_file.read_bytes()).hexdigest()
+            lockfile_contents = self.constraints_file.read_bytes()
+            cross_platform_contents = lockfile_contents.replace(b"\r\n", b"\n")
+            constraint_sha = hashlib.sha256(cross_platform_contents).hexdigest()
             constraints_path = self.constraints_file.relative_to(self.project_root).as_posix()
             constraints_line = f"# [constraints] {constraints_path} (SHA256: {constraint_sha})"
             joined_dependencies = "\n".join([constraints_line, "#", joined_dependencies])
@@ -156,7 +158,9 @@ class PipCompileLock:
         """
         Get hash of lock file
         """
-        return hashlib.sha256(self.lock_file.read_bytes()).hexdigest()
+        lockfile_contents = self.lock_file.read_bytes()
+        cross_platform_contents = lockfile_contents.replace(b"\r\n", b"\n")
+        return hashlib.sha256(cross_platform_contents).hexdigest()
 
     def read_lock_requirements(self) -> List[Requirement]:
         """

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,6 +6,7 @@ interaction between the various components of hatch-pip-compile
 and external tools (pip-tools / pip).
 """
 
+import sys
 from typing import Dict, Type
 
 import hatch
@@ -28,6 +29,8 @@ def test_new_dependency(
     """
     Test adding a new dependency
     """
+    if installer == "pip-sync" and sys.platform == "win32":
+        pytest.skip("Flaky test on Windows")
     original_requirements = pip_compile.default_environment.piptools_lock.read_header_requirements()
     assert original_requirements == [packaging.requirements.Requirement("hatch")]
     pip_compile.toml_doc["project"]["dependencies"] = ["requests"]


### PR DESCRIPTION
This PR resolves an issue where file hashes were different between Windows and Unix due to `CRLF` vs `LF` line endings.

This PR adds a new testing environment in Windows, but skips `tests/test_integration.py::test_new_dependency[pip-sync]` test on Windows due to an unknown issue - this needs to be investigated further (see [job # 20328079974](https://github.com/juftin/hatch-pip-compile/actions/runs/7470039080/job/20328079974), issue to come.)

closes #58 