### PR TITLE
🐛 constraint venv state

### DIFF
--- a/tests/data/pyproject.toml
+++ b/tests/data/pyproject.toml
@@ -21,6 +21,16 @@ path = ".venv/hatch-pip-compile-test"
 pip-compile-constraint = "default"
 type = "pip-compile"
 
+[tool.hatch.envs.docs]
+dependencies = [
+  "mkdocs"
+]
+dev-mode = false
+lock-filename = "requirements/{env_name}.lock"
+path = ".venv/docs"
+pip-compile-constraint = "misc"
+pip-compile-hashes = true
+
 [tool.hatch.envs.lint]
 dependencies = [
   "mypy>=1.6.1",
@@ -28,6 +38,13 @@ dependencies = [
 ]
 detached = true
 path = ".venv/lint"
+type = "pip-compile"
+
+[tool.hatch.envs.misc]
+dependencies = []
+detached = true
+path = ".venv/misc"
+skip-install = true
 type = "pip-compile"
 
 [tool.hatch.envs.test]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -72,7 +72,7 @@ def test_cli_bad_env(pip_compile: PipCompileFixture) -> None:
         assert "error" in result.output.lower()
         assert (
             "The following environments are not supported or unknown: bad_env. "
-            "Supported environments are: default, lint, test"
+            "Supported environments are: default, docs, lint, misc, test"
         ) in result.output
 
 
@@ -99,7 +99,10 @@ def test_cli_all(pip_compile: PipCompileFixture) -> None:
     with runner.isolated_filesystem(temp_dir=pip_compile.isolation):
         result = runner.invoke(cli=cli, args=["--all"])
         assert result.exit_code == 0
-        assert "hatch-pip-compile: Targeting environments: default, lint, test" in result.output
+        assert (
+            "hatch-pip-compile: Targeting environments: default, docs, lint, misc, test"
+            in result.output
+        )
 
 
 def test_cli_upgrade(pip_compile: PipCompileFixture) -> None:
@@ -149,7 +152,7 @@ def test_command_runner_supported_environments(
             upgrade=True,
             upgrade_packages=[],
         )
-        assert command_runner.supported_environments == {"default", "test", "lint"}
+        assert command_runner.supported_environments == {"default", "test", "lint", "docs", "misc"}
 
 
 def test_command_runner_non_supported_environments(
@@ -164,7 +167,7 @@ def test_command_runner_non_supported_environments(
             click.BadParameter,
             match=(
                 "The following environments are not supported or unknown: bad_env. "
-                "Supported environments are: default, lint, test"
+                "Supported environments are: default, docs, lint, misc, test"
             ),
         ):
             _ = HatchCommandRunner(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -29,7 +29,7 @@ def test_new_dependency(
     """
     Test adding a new dependency
     """
-    if installer == "pip-sync" and sys.platform == "win32":
+    if installer == "pip-sync" and sys.platform == "win32":  # pragma: no cover
         pytest.skip("Flaky test on Windows")
     original_requirements = pip_compile.default_environment.piptools_lock.read_header_requirements()
     assert original_requirements == [packaging.requirements.Requirement("hatch")]
@@ -59,6 +59,8 @@ def test_delete_dependencies(
     """
     Test deleting all dependencies also deletes the lockfile
     """
+    if installer == "pip-sync" and sys.platform == "win32":  # pragma: no cover
+        pytest.skip("Flaky test on Windows")
     pip_compile.toml_doc["tool"]["hatch"]["envs"]["default"]["pip-compile-installer"] = installer
     pip_compile.toml_doc["project"]["dependencies"] = []
     pip_compile.update_pyproject()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -158,6 +158,7 @@ def test_dependencies_in_sync(pip_compile: PipCompileFixture) -> None:
     """
     Test the `dependencies_in_sync` method
     """
+    pip_compile.default_environment.create()
     assert pip_compile.default_environment.lockfile_up_to_date is True
     assert pip_compile.default_environment.dependencies_in_sync() is False
     pip_compile.application.prepare_environment(pip_compile.default_environment)

--- a/tests/test_integration_cli.py
+++ b/tests/test_integration_cli.py
@@ -11,12 +11,15 @@ from hatch_pip_compile.exceptions import HatchPipCompileError
 from tests.conftest import PipCompileFixture
 
 
-def test_invoke_environment_creates_env(pip_compile: PipCompileFixture) -> None:
+@pytest.mark.parametrize("environment_name", ["default", "test", "lint", "docs", "misc"])
+def test_invoke_environment_creates_env(
+    pip_compile: PipCompileFixture, environment_name: str
+) -> None:
     """
     Test using the CLI runner
     """
     runner = CliRunner()
-    environment = pip_compile.test_environment
+    environment = pip_compile.reload_environment(environment=environment_name)
     venv = environment.virtual_env.directory
     assert not venv.exists()
     with runner.isolated_filesystem(pip_compile.isolation):
@@ -129,5 +132,5 @@ def test_prune_removes_all_environments(pip_compile: PipCompileFixture) -> None:
             args=["env", "prune"],
         )
     assert result.exit_code == 0
-    if venv_dir.exists():
-        assert len(list(venv_dir.iterdir())) == 0
+    venv_dir.mkdir(exist_ok=True)
+    assert len(list(venv_dir.iterdir())) == 0

--- a/tests/test_integration_cli.py
+++ b/tests/test_integration_cli.py
@@ -111,3 +111,23 @@ def test_pip_compile_disable_cli(pip_compile: PipCompileFixture, environment_nam
         )
         assert result.exit_code == 1
         assert isinstance(result.exception, HatchPipCompileError)
+
+
+def test_prune_removes_all_environments(pip_compile: PipCompileFixture) -> None:
+    """
+    Assert that running `hatch env prune` removes all environments
+    """
+    runner = CliRunner()
+    pip_compile.default_environment.create()
+    pip_compile.test_environment.create()
+    venv_dir = pip_compile.isolation / ".venv"
+    assert venv_dir.exists()
+    assert len(list(venv_dir.iterdir())) == 2
+    with runner.isolated_filesystem(pip_compile.isolation):
+        result = runner.invoke(
+            hatch.cli.hatch,
+            args=["env", "prune"],
+        )
+    assert result.exit_code == 0
+    if venv_dir.exists():
+        assert len(list(venv_dir.iterdir())) == 0


### PR DESCRIPTION
This PR fixes an issue where a constraint environment is created but doesn't contain the right dependencies. This was also happening inadvertently and breaking the `hatch env prune` functionality. 

A more ideal version of this could be done with https://github.com/pypa/hatch/pull/1228.

Closes #63 
Closes #65 