### PR TITLE
🐛 Replace temporary lockfile name properly on Windows

### DIFF
--- a/hatch_pip_compile/lock.py
+++ b/hatch_pip_compile/lock.py
@@ -39,11 +39,7 @@ class PipCompileLock(HatchPipCompileBase):
         prefix = dedent(raw_prefix).strip()
         joined_dependencies = "\n".join([f"# - {dep}" for dep in self.environment.dependencies])
         lockfile_text = lockfile.read_text()
-        cleaned_input_file = re.sub(
-            rf"-r \S*[\\/]{self.environment.name}\.in",
-            f"hatch.envs.{self.environment.name}",
-            lockfile_text,
-        )
+        cleaned_input_file = self.replace_temporary_lockfile(lockfile_text=lockfile_text)
         if self.environment.piptools_constraints_file is not None:
             lockfile_contents = self.environment.piptools_constraints_file.read_bytes()
             cross_platform_contents = lockfile_contents.replace(b"\r\n", b"\n")
@@ -167,3 +163,14 @@ class PipCompileLock(HatchPipCompileBase):
             session=PipSession(),
         )
         return [ireq.req for ireq in install_requirements]  # type: ignore[misc]
+
+    def replace_temporary_lockfile(self, lockfile_text: str) -> str:
+        """
+        Replace the temporary lockfile with the new lockfile
+        """
+        cleaned_input_file = re.sub(
+            rf"-r \S*[\\/]{self.environment.name}\.in",
+            f"hatch.envs.{self.environment.name}",
+            lockfile_text,
+        )
+        return cleaned_input_file

--- a/hatch_pip_compile/lock.py
+++ b/hatch_pip_compile/lock.py
@@ -40,7 +40,7 @@ class PipCompileLock(HatchPipCompileBase):
         joined_dependencies = "\n".join([f"# - {dep}" for dep in self.environment.dependencies])
         lockfile_text = lockfile.read_text()
         cleaned_input_file = re.sub(
-            rf"-r \S*/{self.environment.name}\.in",
+            rf"-r \S*[\\/]{self.environment.name}\.in",
             f"hatch.envs.{self.environment.name}",
             lockfile_text,
         )

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,6 +1,7 @@
 """
 Testing the `lock` module
 """
+from textwrap import dedent
 
 from packaging.requirements import Requirement
 from packaging.version import Version
@@ -67,3 +68,41 @@ def test_read_lock_requirements(pip_compile: PipCompileFixture) -> None:
         "ruff==0.1.6",
         "typing-extensions==4.8.0",
     }
+
+
+def test_replace_temporary_lockfile_windows(pip_compile: PipCompileFixture) -> None:
+    """
+    Regex Replace Temporary File Path: Windows
+    """
+    lock_raw = r"""
+    httpx==0.22.0
+        # via -r C:\Users\xxx\AppData\Local\Temp\tmp_kn984om\default.in
+    """
+    lock_body = dedent(lock_raw).strip()
+    cleaned_text = pip_compile.default_environment.piptools_lock.replace_temporary_lockfile(
+        lock_body
+    )
+    expected_raw = r"""
+    httpx==0.22.0
+        # via hatch.envs.default
+    """
+    assert cleaned_text == dedent(expected_raw).strip()
+
+
+def test_replace_temporary_lockfile_unix(pip_compile: PipCompileFixture) -> None:
+    """
+    Regex Replace Temporary File Path: Unix
+    """
+    lock_raw = r"""
+    httpx==0.22.0
+        # via -r /tmp/tmp_kn984om/default.in
+    """
+    lock_body = dedent(lock_raw).strip()
+    cleaned_text = pip_compile.default_environment.piptools_lock.replace_temporary_lockfile(
+        lock_body
+    )
+    expected_raw = r"""
+    httpx==0.22.0
+        # via hatch.envs.default
+    """
+    assert cleaned_text == dedent(expected_raw).strip()


### PR DESCRIPTION
Hello!

I'm using your plugin on Windows and it works really well. However, it doesn't properly detect the temporary `requirements.in` filename, leading to this in my lockfile:

```py
httpx==0.22.0
    # via -r C:\Users\xxx\AppData\Local\Temp\tmp_kn984om\test-two.in
```

The [regex used to replace this](https://github.com/juftin/hatch-pip-compile/blob/559012890ab2992bea79b336da5c77d745023144/hatch_pip_compile/lock.py#L43) is `rf"-r \S*/{self.environment.name}\.in"`, which doesn't account for backslashes. I changed it to `rf"-r \S*[\\/]{self.environment.name}\.in"`.
