### PR TITLE
🐛 typo in env var name

### DIFF
--- a/hatch_pip_compile/cli.py
+++ b/hatch_pip_compile/cli.py
@@ -67,7 +67,7 @@ class HatchCommandRunner:
                 "[bold green]hatch-pip-compile[/bold green]: Upgrading all dependencies"
             )
         elif self.upgrade_packages:
-            env_vars["PIP_COMPILE_UPGRADE_PACKAGES"] = ",".join(self.upgrade_packages)
+            env_vars["PIP_COMPILE_UPGRADE_PACKAGE"] = ",".join(self.upgrade_packages)
             message = (
                 "[bold green]hatch-pip-compile[/bold green]: "
                 f"Upgrading packages: {', '.join(self.upgrade_packages)}"


### PR DESCRIPTION
Should be `PIP_COMPILE_UPGRADE_PACKAGE` not `PIP_COMPILE_UPGRADE_PACKAGES`