### PR TITLE
🐛 extract relevant output from `hatch env show --json`

### DIFF
--- a/hatch_pip_compile/cli.py
+++ b/hatch_pip_compile/cli.py
@@ -139,7 +139,12 @@ class HatchCommandRunner:
             capture_output=True,
             check=True,
         )
-        environment_dict: dict[str, Any] = json.loads(result.stdout)
+        # Extract the relevant JSON output by extracting the last line in stdout,
+        # to prevent JSONDecodeError. 
+        # When present, previous lines might be logs from Hatch plugins,
+        # like custom environment collectors.
+        envs_raw = result.stdout.strip().rsplit(b"\n", maxsplit=1)[-1] 
+        environment_dict: dict[str, Any] = json.loads(envs_raw)
         return {
             key for key, value in environment_dict.items() if value.get("type") == "pip-compile"
         }


### PR DESCRIPTION
If `result.stdout` contains something more than the JSON output of all the environments, such as logs from Hatch plugins/hooks, this will result in JSONDecodeError. We must extract the relevant output to prevent such cases.