### PR TITLE
plugin.py: fix get_option_types

### DIFF
--- a/hatch_pip_compile/plugin.py
+++ b/hatch_pip_compile/plugin.py
@@ -91,10 +91,10 @@ class PipCompileEnvironment(VirtualEnvironment):
         return {  # pragma: no cover
             "lock-filename": str,
             "pip-compile-hashes": bool,
-            "pip-compile-args": List[str],
+            "pip-compile-args": list,
             "pip-compile-constraint": str,
             "pip-compile-installer": str,
-            "pip-compile-install-args": List[str],
+            "pip-compile-install-args": list,
             "pip-compile-resolver": str,
         }
 


### PR DESCRIPTION
Fixes being unable to use `pip-compile-args` with "Matrix Variable Overrides" like documented in https://hatch.pypa.io/1.13/config/environment/advanced/#matrix-variable-overrides

hatch's `apply_overrides()` only checks whether the type is `list` and does not support `typing`-s `List`. For reference see https://github.com/pypa/hatch/blob/master/src/hatch/project/env.py#L46

---

I have confirmed that this works on my machine. Without the change I get the error 
```
ValueError: Untyped option `tool.hatch.envs.test.py3.11.overrides.matrix.python.pip-compile-args` must be defined as a table with a `value` key
```

With the change I can use the overrides as documented.